### PR TITLE
Set cookie in response and return version in endpoint data.

### DIFF
--- a/serrano/resources/__init__.py
+++ b/serrano/resources/__init__.py
@@ -6,7 +6,7 @@ import serrano
 from serrano.tokens import token_generator
 from .base import BaseResource
 
-API_VERSION = int('{major}{minor}'.format(**serrano.__version_info__))
+API_VERSION = '{major}.{minor}.{micro}'.format(**serrano.__version_info__)
 
 class Root(BaseResource):
     # Override to allow a POST to not be checked for authorization since

--- a/serrano/resources/exporter.py
+++ b/serrano/resources/exporter.py
@@ -1,4 +1,4 @@
-import serrano
+from serrano.resources import API_VERSION
 from datetime import datetime
 from django.http import HttpResponse, Http404
 from django.conf.urls import patterns, url
@@ -17,7 +17,7 @@ class ExporterRootResource(resources.Resource):
 
         resp = {
             'title': 'Serrano Exporter Endpoints',
-            'version': serrano.__version_info__,
+            'version': API_VERSION,
             '_links': {
                 'self': {
                     'href': uri(reverse('serrano:data:exporter')),


### PR DESCRIPTION
By setting the cookie in the response, the client is able to tell when
the export(for each type) has finished. Also, by returning the version
as part of the endpoint data. The client will be able to determine
whether they can rely on the cookie being set or if they need to work
without the cookie.

These changes will be critical to upcoming changes in Cilantro related to exporting as Cilantro will rely on the cookies to know when downloads finish and use the version to know whether to expect cookies or not.
