### PR TITLE
Add POST support for validation of field values

### DIFF
--- a/serrano/resources/field/values.py
+++ b/serrano/resources/field/values.py
@@ -106,8 +106,9 @@ class FieldValues(FieldBase):
 
         try:
             values = map(lambda x: x['value'], array)
-        except (ValueError, TypeError):
-            return HttpResponse('Error parsing value', status=codes.UNPROCESSIBLE_ENTITY)
+        except (KeyError, TypeError) as e:
+            return HttpResponse('Error parsing value',
+                status=codes.unprocessable_entity)
 
         field_name = instance.field_name
 
@@ -116,10 +117,12 @@ class FieldValues(FieldBase):
         queryset = self.get_base_values(request, instance, params)
         lookup = {'{0}__in'.format(field_name): values}
 
-        results = set(queryset.filter(**lookup).values_list(field_name, flat=True))
+        results = set(queryset.filter(**lookup)\
+            .values_list(field_name, flat=True))
 
         for datum in array:
             datum['label'] = instance.get_label(datum['value'])
             datum['valid'] = datum['value'] in results
 
+        # Return the augmented data
         return request.data

--- a/tests/cases/resources/tests.py
+++ b/tests/cases/resources/tests.py
@@ -202,6 +202,20 @@ class FieldResourceTestCase(BaseTestCase):
             {'value': 'Programmer', 'label': 'Programmer', 'valid': True},
         ])
 
+        # Error - no value
+        response = self.client.post('/api/fields/2/values/',
+            data=json.dumps({}),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 422)
+
+        # Error - type
+        response = self.client.post('/api/fields/2/values/',
+            data=json.dumps(None),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 422)
+
     def test_stats(self):
         # title.name
         response = self.client.get('/api/fields/2/stats/',


### PR DESCRIPTION
This takes a JSON-encoded object or array and echos back the data with
the value `label` and a `valid` flag for each input.

Currently, this only checks if the value exists in the data. Future
enhancements could provide a reason why validation failed, e.g. 'does
not exist', 'out of bounds', etc.
