### PR TITLE
Fix FieldDistribution to count relative to specified tree

### DIFF
--- a/tests/cases/resources/tests.py
+++ b/tests/cases/resources/tests.py
@@ -272,7 +272,7 @@ class FieldResourceTestCase(BaseTestCase):
             HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content), {
-            u'size': 5,
+            u'size': 4,
             u'clustered': False,
             u'outliers': [],
             u'data': [{
@@ -284,9 +284,6 @@ class FieldResourceTestCase(BaseTestCase):
             }, {
                 u'count': 1,
                 u'values': [20000]
-            }, {
-                u'count': 1,
-                u'values': [100000]
             }, {
                 u'count': 1,
                 u'values': [200000]

--- a/tests/fixtures/test_data.json
+++ b/tests/fixtures/test_data.json
@@ -99,7 +99,7 @@
             "last_name": "Smith",
             "is_manager": false,
             "office": 1,
-            "title": 1
+            "title": 3
         }
     },
     {
@@ -110,7 +110,7 @@
             "last_name": "Harris",
             "is_manager": false,
             "office": 1,
-            "title": 2
+            "title": 4
         }
     },
     {
@@ -121,7 +121,7 @@
             "last_name": "Cook",
             "is_manager": false,
             "office": 1,
-            "title": 1
+            "title": 5
         }
     },
     {
@@ -132,7 +132,7 @@
             "last_name": "Brooks",
             "is_manager": false,
             "office": 1,
-            "title": 2
+            "title": 6
         }
     }
 ]


### PR DESCRIPTION
Previously, counts were record-based however this effectively "broke" the distribution for fields that went through a many-to-many relationship.

The caveat to this fix is that fields that contain values that are not associated to the records in the root model will not be included in the distribution (with a count of 0).
