### PR TITLE
Add handlers for cases where there are orphan fields in concept and field GET enpoints

### DIFF
--- a/serrano/resources/base.py
+++ b/serrano/resources/base.py
@@ -216,6 +216,10 @@ class BaseResource(Resource):
         "Returns a DataQuery object based on `attrs` or the request."
         return get_request_query(request, attrs=attrs)
 
+    @property
+    def checks_for_orphans(self):
+        return getattr(settings, 'SERRANO_CHECK_ORPHANED_FIELDS', True)
+
 
 class DataResource(BaseResource):
     def __init__(self, **kwargs):

--- a/serrano/resources/concept.py
+++ b/serrano/resources/concept.py
@@ -172,7 +172,8 @@ class ConceptResource(ConceptBase):
         params = self.get_params(request)
         instance = request.instance
 
-        if params['embed'] and has_orphaned_field(instance):
+        if (self.checks_for_orphans and params['embed'] and
+                has_orphaned_field(instance)):
             return HttpResponse(status=codes.internal_server_error,
                 content="Could not get concept because it has one or more "
                     "orphaned fields.")
@@ -190,7 +191,7 @@ class ConceptFieldsResource(ConceptBase):
         fields = []
         resource = FieldResource()
 
-        if has_orphaned_field(instance):
+        if self.checks_for_orphans and has_orphaned_field(instance):
             return HttpResponse(status=codes.internal_server_error,
                 content="Could not get concept fields because one or more are "
                     "linked to orphaned fields.")
@@ -254,7 +255,7 @@ class ConceptsResource(ConceptBase):
 
             objects = queryset
 
-        if params['embed']:
+        if self.checks_for_orphans and params['embed']:
             pks = []
             for obj in objects:
                 if not has_orphaned_field(obj):


### PR DESCRIPTION
The behavior of the endpoints follow the requirements outlined in #51. There are tests against each of the endpoints outline in #51 both for normal and orphaned states.
