### PR TITLE
Replace param_cleaners with restlib2.params.*Param classes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 avocado>=2.1a,<2.2
 django-preserialize>=1.0.4,<1.1.0
-restlib2>=0.3.7,<0.4
+restlib2>=0.3.9,<0.4
 python-memcached>=1.48

--- a/serrano/resources/base.py
+++ b/serrano/resources/base.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from preserialize.serialize import serialize
-from restlib2.params import Parametizer, param_cleaners
+from restlib2.params import Parametizer, BoolParam, IntParam
 from restlib2.resources import Resource
 from avocado.history.models import Revision
 from avocado.models import DataContext, DataView, DataQuery
@@ -288,14 +288,8 @@ class DataResource(BaseResource):
 
 
 class PaginatorParametizer(Parametizer):
-    page = 1
-    limit = 20
-
-    def clean_page(self, value):
-        return param_cleaners.clean_int(value)
-
-    def clean_limit(self, value):
-        return param_cleaners.clean_int(value)
+    page = IntParam(1)
+    limit = IntParam(20)
 
 
 class PaginatorResource(Resource):
@@ -377,10 +371,7 @@ class RevisionParametizer(Parametizer):
     """
     Support params and their defaults for Revision endpoints.
     """
-    embed = False
-
-    def clean_embed(self, value):
-        return param_cleaners.clean_bool(value)
+    embed = BoolParam(False)
 
 
 class RevisionsResource(DataResource):

--- a/serrano/resources/concept.py
+++ b/serrano/resources/concept.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from preserialize.serialize import serialize
 from restlib2.http import codes
-from restlib2.params import Parametizer, param_cleaners
+from restlib2.params import Parametizer, BoolParam, StrParam, IntParam
 from avocado.events import usage
 from avocado.models import DataConcept, DataCategory
 from avocado.conf import OPTIONAL_DEPS
@@ -77,28 +77,13 @@ def concept_posthook(instance, data, request, embed, brief, categories=None):
 class ConceptParametizer(Parametizer):
     "Supported params and their defaults for Concept endpoints."
 
-    sort = None
-    order = 'asc'
-    published = None
-    embed = False
-    brief = False
-    query = ''
-    limit = None
-
-    def clean_embed(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_brief(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_published(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_query(self, value):
-        return param_cleaners.clean_string(value)
-
-    def clean_limit(self, value):
-        return param_cleaners.clean_int(value)
+    sort = StrParam()
+    order = StrParam('asc')
+    published = BoolParam()
+    embed = BoolParam(False)
+    brief = BoolParam(False)
+    query = StrParam()
+    limit = IntParam()
 
 
 class ConceptBase(DataResource):

--- a/serrano/resources/exporter.py
+++ b/serrano/resources/exporter.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse, Http404
 from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse
 from restlib2 import resources
-from restlib2.params import Parametizer, param_cleaners
+from restlib2.params import Parametizer, IntParam, StrParam
 from modeltree.tree import MODELTREE_DEFAULT_ALIAS, trees
 from avocado.export import registry as exporters
 from avocado.query import pipeline
@@ -39,16 +39,8 @@ class ExporterRootResource(resources.Resource):
 
 
 class ExporterParametizer(Parametizer):
-    limit = 50
-    tree = MODELTREE_DEFAULT_ALIAS
-
-    def clean_limit(self, value):
-        return param_cleaners.clean_int(value)
-
-    def clean_tree(self, value):
-        if value not in trees:
-            return MODELTREE_DEFAULT_ALIAS
-        return value
+    limit = IntParam(50)
+    tree = StrParam(MODELTREE_DEFAULT_ALIAS, choices=trees)
 
 
 class ExporterResource(BaseResource):

--- a/serrano/resources/field/base.py
+++ b/serrano/resources/field/base.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse
 from django.core.urlresolvers import reverse
 from preserialize.serialize import serialize
 from restlib2.http import codes
-from restlib2.params import Parametizer, param_cleaners
+from restlib2.params import Parametizer, StrParam, BoolParam, IntParam
 from avocado.models import DataField
 from avocado.events import usage
 from ..base import DataResource
@@ -54,34 +54,16 @@ def field_posthook(instance, data, request):
 class FieldParametizer(Parametizer):
     "Supported params and their defaults for Field endpoints."
 
-    sort = None
-    order = 'asc'
-    published = None
-    brief = False
-    query = ''
-    limit = None
+    sort = StrParam()
+    order = StrParam('asc')
+    published = BoolParam()
+    brief = BoolParam(False)
+    query = StrParam()
+    limit = IntParam()
 
     # Not implemented
-    offset = None
-    page = None
-
-    def clean_published(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_brief(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_query(self, value):
-        return param_cleaners.clean_string(value)
-
-    def clean_limit(self, value):
-        return param_cleaners.clean_int(value)
-
-    def clean_offset(self, value):
-        return param_cleaners.clean_int(value)
-
-    def clean_page(self, value):
-        return param_cleaners.clean_int(value)
+    offset = IntParam()
+    page = IntParam()
 
 
 class FieldBase(DataResource):

--- a/serrano/resources/field/dist.py
+++ b/serrano/resources/field/dist.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from django.db.models import Q
 from django.http import HttpResponse
 from restlib2.http import codes
-from restlib2.params import Parametizer, param_cleaners
+from restlib2.params import Parametizer, StrParam, BoolParam, IntParam
 from modeltree.tree import MODELTREE_DEFAULT_ALIAS, trees
 from avocado.models import DataField
 from avocado.stats import kmeans
@@ -17,36 +17,12 @@ MAXIMUM_OBSERVATIONS = 50000
 
 
 class FieldDistParametizer(Parametizer):
-    tree = MODELTREE_DEFAULT_ALIAS
-    aware = False
-    nulls = False
-    sort = None
-    cluster = True
-    n = None
-
-    # Not implemented
-    aggregates = None
-    relative = None
-
-    def clean_tree(self, value):
-        if value not in trees:
-            return MODELTREE_DEFAULT_ALIAS
-        return value
-
-    def clean_aware(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_nulls(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_sort(self, value):
-        return param_cleaners.clean_string(value)
-
-    def clean_cluster(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_n(self, value):
-        return param_cleaners.clean_int(value)
+    tree = StrParam(MODELTREE_DEFAULT_ALIAS, choices=trees)
+    aware = BoolParam(False)
+    nulls = BoolParam(False)
+    sort = StrParam()
+    cluster = BoolParam(True)
+    n = IntParam()
 
 
 class FieldDistribution(FieldBase):

--- a/serrano/resources/field/values.py
+++ b/serrano/resources/field/values.py
@@ -2,31 +2,18 @@ from django.http import HttpResponse
 from django.core.urlresolvers import reverse
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from restlib2.http import codes
-from restlib2.params import Parametizer, param_cleaners
+from restlib2.params import Parametizer, StrParam, IntParam, BoolParam
 from avocado.conf import OPTIONAL_DEPS
 from avocado.events import usage
 from ..base import PaginatorResource, PaginatorParametizer
 from .base import FieldBase
 
 
-MAXIMUM_RANDOM = 100
-
-
 class FieldValuesParametizer(PaginatorParametizer):
-    limit = 10
-    aware = False
-    query = None
-    random = None
-
-    def clean_aware(self, value):
-        return param_cleaners.clean_bool(value)
-
-    def clean_query(self, value):
-        return param_cleaners.clean_string(value)
-
-    def clean_random(self, value):
-        value = param_cleaners.clean_int(value)
-        return min(value, MAXIMUM_RANDOM)
+    limit = IntParam(10)
+    aware = BoolParam(False)
+    query = StrParam()
+    random = IntParam()
 
 
 class FieldValues(FieldBase, PaginatorResource):

--- a/serrano/resources/preview.py
+++ b/serrano/resources/preview.py
@@ -8,17 +8,12 @@ from django.core.urlresolvers import reverse
 from modeltree.tree import MODELTREE_DEFAULT_ALIAS, trees
 from avocado.query import pipeline
 from avocado.export import HTMLExporter
-from restlib2.params import Parametizer, param_cleaners
+from restlib2.params import Parametizer, StrParam
 from .base import BaseResource, PaginatorResource, PaginatorParametizer
 
 
 class PreviewParametizer(PaginatorParametizer):
-    tree = MODELTREE_DEFAULT_ALIAS
-
-    def clean_tree(self, value):
-        if value not in trees:
-            return MODELTREE_DEFAULT_ALIAS
-        return value
+    tree = StrParam(MODELTREE_DEFAULT_ALIAS, choices=trees)
 
 
 class PreviewResource(BaseResource, PaginatorResource):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'avocado>=2.1a,<2.2',
-    'restlib2>=0.3.7,<0.4',
+    'restlib2>=0.3.9,<0.4',
     'django-preserialize>=1.0.4,<1.1',
 ]
 


### PR DESCRIPTION
Increase minimum restlib2 version to 0.3.9. Also, MAXIMUM_RANDOM
has been removed since it was an arbitrary cap.

Fix #81
