### PR TITLE
Only include shared users if the request user is the query owner

### DIFF
--- a/serrano/resources/query.py
+++ b/serrano/resources/query.py
@@ -37,6 +37,13 @@ def query_posthook(instance, data, request):
 def shared_query_posthook(instance, data, request):
     data = query_posthook(instance, data, request)
     data['is_owner'] = instance.user == request.user
+
+    # If this user is not the owner then the shared users are not included
+    # because this sort of data should not be exposed to anyone who isn't the
+    # owner of the original query.
+    if not data['is_owner']:
+        del data['shared_users']
+
     return data
 
 class QueryBase(ThrottledResource):

--- a/tests/cases/resources/tests/query.py
+++ b/tests/cases/resources/tests/query.py
@@ -23,6 +23,7 @@ class SharedQueryTestCase(AuthenticatedBaseTestCase):
 
         shared_query = json.loads(response.content)[0]
         self.assertTrue(shared_query['is_owner'])
+        self.assertTrue('shared_users' in shared_query)
 
     def test_owner_and_shared(self):
         # Create a query this user owns
@@ -97,6 +98,7 @@ class SharedQueryTestCase(AuthenticatedBaseTestCase):
 
         shared_query = json.loads(response.content)[0]
         self.assertFalse(shared_query['is_owner'])
+        self.assertFalse('shared_users' in shared_query)
 
     @override_settings(SERRANO_AUTH_REQUIRED=True)
     def test_require_login(self):


### PR DESCRIPTION
This also includes new tests to make sure shared_users is removed when the requesting user is not the owner.
