### PR TITLE
Expose distribution endpoint for auto and key-based fields

### DIFF
--- a/tests/cases/resources/tests/concept.py
+++ b/tests/cases/resources/tests/concept.py
@@ -59,8 +59,10 @@ class ConceptResourceTestCase(BaseTestCase):
         # are about to retrieve.
         DataField.objects.filter(pk=2).update(field_name='XXX')
 
-        self.assertRaises(AttributeError, self.client.get, '/api/concepts/',
-            {'embed': True}, HTTP_ACCEPT='application/json')
+        response = self.client.get('/api/concepts/', {'embed': True},
+            HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json.loads(response.content)), 2)
 
         # If we aren't embedding the fields, then none of the concepts
         # should be filtered out.
@@ -98,8 +100,9 @@ class ConceptResourceTestCase(BaseTestCase):
         # Orphan one of the fields on the concept before we retrieve it
         DataField.objects.filter(pk=2).update(model_name="XXX")
 
-        self.assertRaises(AttributeError, self.client.get, '/api/concepts/1/',
-            {'embed': True}, HTTP_ACCEPT='application/json')
+        response = self.client.get('/api/concepts/1/', {'embed': True},
+            HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
 
         # If we aren't embedding the fields, there should not be a server error
         response = self.client.get('/api/concepts/1/',
@@ -145,5 +148,6 @@ class ConceptFieldResourceTestCase(BaseTestCase):
         # the fields for.
         DataField.objects.filter(pk=2).update(field_name="XXX")
 
-        self.assertRaises(AttributeError, self.client.get,
-            '/api/concepts/1/fields/', HTTP_ACCEPT='application/json')
+        response = self.client.get('/api/concepts/1/fields/',
+            HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)

--- a/tests/cases/resources/tests/field.py
+++ b/tests/cases/resources/tests/field.py
@@ -25,8 +25,10 @@ class FieldResourceTestCase(BaseTestCase):
         # Orphan one of the fields we are about to retrieve
         DataField.objects.filter(pk=2).update(field_name="XXX")
 
-        self.assertRaises(AttributeError, self.client.get, '/api/fields/',
+        response = self.client.get('/api/fields/',
             HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json.loads(response.content)), 5)
 
     def test_get_one(self):
         # Not allowed to see
@@ -53,8 +55,9 @@ class FieldResourceTestCase(BaseTestCase):
         # Orphan one of the fields we are about to retrieve
         DataField.objects.filter(pk=2).update(field_name="XXX")
 
-        self.assertRaises(AttributeError, self.client.get, '/api/fields/2/',
+        response = self.client.get('/api/fields/2/',
             HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
 
     def test_get_privileged(self):
         # Superuser sees everything


### PR DESCRIPTION
This change also resolves a side-effect seen when calling stats_capable
which relied on the `internal_type` of the field. When a field is orphaned,
this threw an error since the underlying model field does not exist.
The tests were updated to remove handling this side effect and actually
test the result.

Fix #105
