### PR TITLE
Unset limit when page or page range is not specified

### DIFF
--- a/serrano/resources/exporter.py
+++ b/serrano/resources/exporter.py
@@ -68,19 +68,19 @@ class ExporterResource(BaseResource):
         if page:
             page = int(page)
 
-            # params are 1-based
+            # Pages are 1-based
             if page < 1:
                 raise Http404
 
             file_tag = 'p{0}'.format(page)
 
-            # change to 0-base
+            # Change to 0-base for calculating offset
             offset = limit * (page - 1)
 
             if stop_page:
                 stop_page = int(stop_page)
 
-                # cannot have a lower index than page
+                # Cannot have a lower index than page
                 if stop_page < page:
                     raise Http404
 
@@ -91,6 +91,8 @@ class ExporterResource(BaseResource):
                     limit = limit * stop_page
 
         else:
+            # When no page or range is specified, the limit does not apply.
+            limit = None
             file_tag = 'all'
 
         QueryProcessor = pipeline.query_processors.default


### PR DESCRIPTION
Fix #110 (backport of c627b01961dc40ec9e34123ca1065603e883783b in branch 2.2).

I'd like to do an app release today or tomorrow with Avocado and Serrano 2.1.  If 2.2 isn't going to be released for a while, then this backport would make the 2.1 branch usable for me.
