### PR TITLE
Add ping resource and endpoint for session and system status

### DIFF
--- a/serrano/resources/__init__.py
+++ b/serrano/resources/__init__.py
@@ -1,10 +1,16 @@
+from urlparse import urlparse
 from django.http import HttpResponse
+from django.utils.http import is_safe_url
+from django.conf import settings as django_settings
 from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse
 from django.contrib.auth import authenticate, login
+from restlib2.resources import Resource
+from restlib2.http import codes
 import serrano
-from serrano.conf import dep_supported
+from serrano.conf import dep_supported, settings
 from serrano.tokens import token_generator
+from serrano import cors
 from .base import BaseResource
 
 API_VERSION = '{major}.{minor}.{micro}'.format(**serrano.__version_info__)
@@ -55,6 +61,9 @@ class Root(BaseResource):
                 'exporter': {
                     'href': uri(reverse('serrano:data:exporter')),
                 },
+                'ping': {
+                    'href': uri(reverse('serrano:ping')),
+                },
             }
         }
 
@@ -79,6 +88,57 @@ class Root(BaseResource):
         return HttpResponse('Invalid credentials', status=401)
 
 
-root_resource = Root()
+class Ping(Resource):
+    """Dedicated resource for pinging the service. This is used for detecting
+    session timeouts. This resource does not impact the session on a request
+    and thus allows for the session to naturally timeout.
 
-urlpatterns = patterns('', url(r'^$', root_resource, name='root'))
+    The response code will always be 200, however the payload will contain the
+    real code and status, such as 'timeout', with any other relevant
+    information. This decision was facilitate browser clients whose behavior
+    will vary when using real response codes.
+    """
+    def process_response(self, request, response):
+        response = super(Ping, self).process_response(request, response)
+        return cors.patch_response(request, response, self.allowed_methods)
+
+    def get(self, request):
+        resp = {
+            'code': codes.ok,
+            'status': 'ok',
+        }
+
+        if settings.AUTH_REQUIRED:
+            user = getattr(request, 'user')
+
+            if not user or not user.is_authenticated():
+                ref = request.META.get('HTTP_REFERER', '')
+
+                if ref and is_safe_url(url=ref, host=request.get_host()):
+                    # Construct redirect to referring page since redirecting
+                    # back to an API endpoint does not useful
+                    path = urlparse(ref).path
+                else:
+                    path = django_settings.LOGIN_REDIRECT_URL
+
+                location = '{0}?next={1}'.format(django_settings.LOGIN_URL,
+                                                 path)
+                url = request.build_absolute_uri(location)
+
+                resp = {
+                    'code': codes.found,
+                    'status': 'timeout',
+                    'location': url,
+                }
+
+        return self.render(request, resp)
+
+
+root_resource = Root()
+ping_resource = Ping()
+
+urlpatterns = patterns(
+    '',
+    url(r'^$', root_resource, name='root'),
+    url(r'^ping/$', ping_resource, name='ping'),
+)

--- a/serrano/urls.py
+++ b/serrano/urls.py
@@ -15,7 +15,7 @@ data_patterns = patterns(
 serrano_patterns = patterns(
     '',
 
-    url(r'^$',
+    url(r'^',
         include('serrano.resources')),
 
     url(r'^categories/',


### PR DESCRIPTION
In practice, this requires the SESSION_SAVE_EVERY_REQUEST Django setting
to be false since the act of pinging the server would refresh the session.

This also only works when Serrano requires authentication and the
AUTH_REQUIRED setting is set to true. Django's session behavior is to
transparently generate a new session key for requests if one is not
present or it has expired for the requester.

Fix #86
