### PR TITLE
Apply offset and limit arguments in exporter

### DIFF
--- a/serrano/__init__.py
+++ b/serrano/__init__.py
@@ -1,7 +1,7 @@
 __version_info__ = {
     'major': 2,
-    'minor': 2,
-    'micro': 1,
+    'minor': 3,
+    'micro': 0,
     'releaselevel': 'beta',
     'serial': 1
 }

--- a/serrano/resources/exporter.py
+++ b/serrano/resources/exporter.py
@@ -100,10 +100,11 @@ class ExporterResource(BaseResource):
                                    include_pk=False)
 
         exporter = processor.get_exporter(exporters[export_type])
-        iterable = processor.get_iterable(offset=offset, limit=limit)
+        iterable = processor.get_iterable()
 
         # Write the data to the response
-        exporter.write(iterable, resp, request=request)
+        exporter.write(iterable, resp, request=request, offset=offset,
+                       limit=limit)
 
         filename = '{0}-{1}-data.{2}'.format(
             file_tag, datetime.now(), exporter.file_extension)

--- a/serrano/resources/preview.py
+++ b/serrano/resources/preview.py
@@ -50,7 +50,7 @@ class PreviewResource(BaseResource, PaginatorResource):
         offset = max(0, page.start_index() - 1)
 
         # Prepare the exporter and iterable
-        iterable = processor.get_iterable(offset=offset, limit=limit)
+        iterable = processor.get_iterable()
 
         # Build up the header keys.
         # TODO: This is flawed since it assumes the output columns
@@ -73,14 +73,17 @@ class PreviewResource(BaseResource, PaginatorResource):
 
         objects = []
 
-        for row in exporter.read(iterable, request=request):
+        for row in exporter.read(iterable, request=request, offset=offset,
+                                 limit=limit):
             pk = None
             values = []
+
             for i, output in enumerate(row):
                 if i == 0:
                     pk = output[pk_name]
                 else:
                     values.extend(output.values())
+
             objects.append({'pk': pk, 'values': values})
 
         # Various model options

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup, find_packages
 
 install_requires = [
-    'avocado>=2.2,<2.3',
+    'avocado>=2.3,<2.4',
     'restlib2>=0.3.9,<0.4',
     'django-preserialize>=1.0.4,<1.1',
 ]
@@ -21,7 +21,7 @@ kwargs = {
 
     # Test dependencies
     'tests_require': [
-        'avocado[permissions,search,extras]>=2.2,<2.3'
+        'avocado[permissions,search,extras]>=2.3,<2.4'
         'coverage',
         'whoosh',
         'python-memcached>=1.48',


### PR DESCRIPTION
Requires Avocado 2.3.0+. The Serrano version has been bumped to 2.3.0
to accommodate this requirement.

Fix #145
