### PR TITLE
Replace HttpResponse with Resource.render calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+git://github.com/cbmi/avocado.git
-django-preserialize>=1.0.4,<1.1.0
-restlib2>=0.3.9,<0.4
+django-preserialize>=1.0.6,<1.1.0
+restlib2>=0.4.1,<0.5.0
 python-memcached>=1.48
 django-objectset>=0.2.3

--- a/serrano/resources/__init__.py
+++ b/serrano/resources/__init__.py
@@ -1,5 +1,4 @@
 from urlparse import urlparse
-from django.http import HttpResponse
 from django.utils.http import is_safe_url
 from django.conf import settings as django_settings
 from django.conf.urls import patterns, url
@@ -76,15 +75,19 @@ class Root(BaseResource):
     def post(self, request):
         username = request.data.get('username')
         password = request.data.get('password')
+
         if username and password:
             user = authenticate(username=username, password=password)
+
             if user:
                 login(request, user)
                 token = token_generator.make(user)
                 data = self.get(request)
                 data['token'] = token
                 return data
-        return HttpResponse('Invalid credentials', status=401)
+
+        return self.render(request, {'message': 'Invalid credentials'},
+                           status=codes.unauthorized)
 
 
 class Ping(Resource):

--- a/serrano/resources/concept.py
+++ b/serrano/resources/concept.py
@@ -2,7 +2,6 @@ import logging
 import functools
 from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse
 from preserialize.serialize import serialize
 from restlib2.http import codes
 from restlib2.params import Parametizer, BoolParam, StrParam, IntParam
@@ -164,10 +163,11 @@ class ConceptResource(ConceptBase):
 
         if (self.checks_for_orphans and params['embed'] and
                 has_orphaned_field(instance)):
-            return HttpResponse(
-                status=codes.internal_server_error,
-                content="Could not get concept because it has one or more "
-                        "orphaned fields.")
+            data = {
+                'message': 'One or more orphaned fields exist'
+            }
+            return self.render(request, data,
+                               status=codes.internal_server_error)
 
         usage.log('read', instance=instance, request=request)
         return self.prepare(request, instance, embed=params['embed'])
@@ -183,10 +183,11 @@ class ConceptFieldsResource(ConceptBase):
         resource = FieldResource()
 
         if self.checks_for_orphans and has_orphaned_field(instance):
-            return HttpResponse(
-                status=codes.internal_server_error,
-                content="Could not get concept fields because one or more are "
-                        "linked to orphaned fields.")
+            data = {
+                'message': 'One or more orphaned fields exist'
+            }
+            return self.render(request, data,
+                               status=codes.internal_server_error)
 
         for cf in instance.concept_fields.select_related('field').iterator():
             field = resource.prepare(request, cf.field)

--- a/serrano/resources/context.py
+++ b/serrano/resources/context.py
@@ -1,7 +1,6 @@
 import functools
 import logging
 from datetime import datetime
-from django.http import HttpResponse
 from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse
 from django.views.decorators.cache import never_cache
@@ -128,7 +127,11 @@ class ContextsResource(ContextBase):
             response = self.render(request, self.prepare(request, instance),
                                    status=codes.created)
         else:
-            response = self.render(request, dict(form.errors),
+            data = {
+                'message': 'Error creating context',
+                'errors': dict(form.errors),
+            }
+            response = self.render(request, data,
                                    status=codes.unprocessable_entity)
         return response
 
@@ -159,7 +162,11 @@ class ContextResource(ContextBase):
             usage.log('update', instance=instance, request=request)
             response = self.render(request, self.prepare(request, instance))
         else:
-            response = self.render(request, dict(form.errors),
+            data = {
+                'message': 'Error updating context',
+                'errors': dict(form.errors),
+            }
+            response = self.render(request, data,
                                    status=codes.unprocessable_entity)
         return response
 
@@ -168,11 +175,13 @@ class ContextResource(ContextBase):
 
         # Cannot delete the current session
         if instance.session:
-            return HttpResponse(status=codes.bad_request)
+            data = {
+                'message': 'Cannot delete session context',
+            }
+            return self.render(request, data, status=codes.bad_request)
 
         instance.delete()
         usage.log('delete', instance=instance, request=request)
-        return HttpResponse(status=codes.no_content)
 
 
 class ContextStatsResource(ContextBase):

--- a/serrano/resources/field/base.py
+++ b/serrano/resources/field/base.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-from django.http import HttpResponse
 from django.core.urlresolvers import reverse
 from preserialize.serialize import serialize
 from restlib2.http import codes
@@ -126,9 +125,11 @@ class FieldResource(FieldBase):
 
         # If the field is an orphan then log an error before returning an error
         if self.checks_for_orphans and is_field_orphaned(instance):
-            return HttpResponse(
-                status=codes.internal_server_error,
-                content="Error occurred when retrieving orphaned field")
+            data = {
+                'message': 'Orphaned field',
+            }
+            return self.render(request, data,
+                               status=codes.internal_server_error)
 
         return self.prepare(request, instance)
 

--- a/serrano/resources/field/dist.py
+++ b/serrano/resources/field/dist.py
@@ -1,7 +1,5 @@
-import json
 from decimal import Decimal
 from django.db.models import Q
-from django.http import HttpResponse
 from restlib2.http import codes
 from restlib2.params import Parametizer, StrParam, BoolParam, IntParam
 from modeltree.tree import MODELTREE_DEFAULT_ALIAS, trees
@@ -106,8 +104,11 @@ class FieldDistribution(FieldBase):
             return resp
 
         if length > MAXIMUM_OBSERVATIONS:
-            return HttpResponse(json.dumps({'error': 'Data too large'}),
-                                status=codes.unprocessable_entity)
+            data = {
+                'message': 'Data too large',
+            }
+            return self.render(request, data,
+                               status=codes.unprocessable_entity)
 
         # Apply ordering. If any of the fields are enumerable, ordering should
         # be relative to those fields. For continuous data, the ordering is

--- a/serrano/resources/field/values.py
+++ b/serrano/resources/field/values.py
@@ -124,7 +124,10 @@ class FieldValues(FieldBase, PaginatorResource):
         params = self.get_params(request)
 
         if not request.data:
-            return self.render(request, 'Error parsing data',
+            data = {
+                'message': 'Error parsing data',
+            }
+            return self.render(request, data,
                                status=codes.unprocessable_entity)
 
         if isinstance(request.data, dict):
@@ -147,7 +150,10 @@ class FieldValues(FieldBase, PaginatorResource):
                 array_map[i] = 'label'
                 labels.append(datum['label'])
             else:
-                return self.render(request, 'Error parsing value or label',
+                data = {
+                    'message': 'Error parsing value or lable'
+                }
+                return self.render(request, data,
                                    status=codes.unprocessable_entity)
 
         field_name = instance.field_name

--- a/serrano/resources/view.py
+++ b/serrano/resources/view.py
@@ -1,7 +1,6 @@
 import functools
 import logging
 from datetime import datetime
-from django.http import HttpResponse
 from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse
 from django.views.decorators.cache import never_cache
@@ -97,7 +96,11 @@ class ViewsResource(ViewBase):
             response = self.render(request, self.prepare(request, instance),
                                    status=codes.created)
         else:
-            response = self.render(request, dict(form.errors),
+            data = {
+                'message': 'Cannot create view',
+                'errors': dict(form.errors),
+            }
+            response = self.render(request, data,
                                    status=codes.unprocessable_entity)
         return response
 
@@ -145,7 +148,11 @@ class ViewResource(ViewBase):
             usage.log('update', instance=instance, request=request)
             response = self.render(request, self.prepare(request, instance))
         else:
-            response = self.render(request, dict(form.errors),
+            data = {
+                'message': 'Cannot update view',
+                'errors': dict(form.errors),
+            }
+            response = self.render(request, data,
                                    status=codes.unprocessable_entity)
         return response
 
@@ -153,11 +160,13 @@ class ViewResource(ViewBase):
         instance = self.get_object(request, **kwargs)
 
         if instance.session:
-            return HttpResponse(status=codes.bad_request)
+            data = {
+                'message': 'Cannot delete session view',
+            }
+            return self.render(request, data, status=codes.bad_request)
 
         instance.delete()
         usage.log('delete', instance=instance, request=request)
-        return HttpResponse(status=codes.no_content)
 
 
 single_resource = never_cache(ViewResource())

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'avocado>=2.3,<2.4',
-    'restlib2>=0.3.9,<0.4',
-    'django-preserialize>=1.0.4,<1.1',
+    'restlib2>=0.4.1,<0.5.0',
+    'django-preserialize>=1.0.6,<1.1',
 ]
 
 if sys.version_info < (2, 7):

--- a/tests/cases/resources/tests/base.py
+++ b/tests/cases/resources/tests/base.py
@@ -64,7 +64,6 @@ class RootResourceTestCase(TestCase):
             content_type='application/json',
             HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, codes.unauthorized)
-        self.assertEqual(response.content, 'Invalid credentials')
 
         response = self.client.post('/api/',
             json.dumps({'username': 'root', 'password': 'password'}),

--- a/tests/cases/resources/tests/context.py
+++ b/tests/cases/resources/tests/context.py
@@ -80,7 +80,7 @@ class ContextResourceTestCase(AuthenticatedBaseTestCase):
         # Attempt to update the name via a PUT request
         response = self.client.put('/api/contexts/1/',
             data=u'{"name":"New Name"}', content_type='application/json')
-        self.assertEqual(response.status_code, codes.no_content)
+        self.assertEqual(response.status_code, codes.ok)
 
         # Make sure our changes from the PUT request are persisted
         response = self.client.get('/api/contexts/1/',

--- a/tests/cases/resources/tests/query.py
+++ b/tests/cases/resources/tests/query.py
@@ -370,7 +370,7 @@ class QueryResourceTestCase(AuthenticatedBaseTestCase):
         # Attempt to update the name via a PUT request
         response = self.client.put('/api/queries/1/',
             data=u'{"name":"New Name"}', content_type='application/json')
-        self.assertEqual(response.status_code, codes.no_content)
+        self.assertEqual(response.status_code, codes.ok)
 
         # Make sure our changes from the PUT request are persisted
         response = self.client.get('/api/queries/1/',

--- a/tests/cases/resources/tests/view.py
+++ b/tests/cases/resources/tests/view.py
@@ -84,7 +84,7 @@ class ViewResourceTestCase(AuthenticatedBaseTestCase):
         # Attempt to update the name via a PUT request
         response = self.client.put('/api/views/1/',
             data=u'{"name":"New Name"}', content_type='application/json')
-        self.assertEqual(response.status_code, codes.no_content)
+        self.assertEqual(response.status_code, codes.ok)
 
         # Make sure our changes from the PUT request are persisted
         response = self.client.get('/api/views/1/',


### PR DESCRIPTION
This ensures responses are processed by the resource and consistently built.
Messages have been added to all responses in the 4xx-5xx range.

Fix #166, #167

Signed-off-by: Byron Ruth b@devel.io
