### PR TITLE
Base resource modified to handle multiple contexts and views

### DIFF
--- a/serrano/resources/base.py
+++ b/serrano/resources/base.py
@@ -83,7 +83,9 @@ def _get_request_object(request, attrs=None, klass=None, key=None):
         kwargs['session'] = True
 
     try:
-        return klass.objects.get(**kwargs)
+        # Check that multiple DataViews or DataContexts are not returned
+        # If there are more than one, return the most recent
+        return klass.objects.filter(**kwargs).latest('modified')
     except klass.DoesNotExist:
         pass
 


### PR DESCRIPTION
Fix #171 
base.py now handles the erroneous case where multiple views or contexts might appear on a user session. Base resource now returns the most recently modified context/view and ignores the duplicates. 

Appropriate tests have also been added to resources tests.

Signed-off-by: Sheik Hassan solergiga@yahoo.com
