### PR TITLE
Use DataField.random in place of (potentially) slow query

### DIFF
--- a/serrano/resources/field/values.py
+++ b/serrano/resources/field/values.py
@@ -62,21 +62,21 @@ class FieldValues(FieldBase, PaginatorResource):
         return results
 
     def get_random_values(self, request, instance, random):
-        """Returns a random set of values. This is useful for pre-populating
-        documents or form fields with example data.
         """
-        queryset = instance.model.objects.only(instance.field_name)\
-            .order_by('?')[:random]
+        Returns a random set of value/label pairs.
 
+        This is useful for pre-populating documents or form fields with
+        example data.
+        """
+        values = instance.random(random)
         results = []
-        value_labels = instance.value_labels()
 
-        for obj in queryset:
-            value = getattr(obj, instance.field_name)
+        for value in values:
             results.append({
-                'label': value_labels.get(value, smart_unicode(value)),
+                'label': instance.get_label(value),
                 'value': value,
             })
+
         return results
 
     def get(self, request, pk):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup, find_packages
 
 install_requires = [
-    'avocado>=2.3.4,<2.4',
+    'avocado>=2.3.5,<2.4',
     'restlib2>=0.4.1,<0.5.0',
     'django-preserialize>=1.0.7,<1.1',
 ]


### PR DESCRIPTION
Fix #182.

This depends on changes to Avocado in cbmi/avocado#214 and will require a new `2.3.5` release of Avocado for this to be fully accepted.

Signed-off-by: Don Naegely naegelyd@gmail.com
