### PR TITLE
Add support for using custom email message when creating a query

### DIFF
--- a/serrano/forms.py
+++ b/serrano/forms.py
@@ -14,9 +14,7 @@ log = logging.getLogger(__name__)
 
 SHARED_QUERY_EMAIL_TITLE = '{site_name}: {query_name} has been shared with '\
                            'you!'
-SHARED_QUERY_EMAIL_BODY = 'The query "{query_name}" has been shared with ' \
-                          'you on {site_name} ({site_url})! You can view ' \
-                          'the query by going to: {query_url}.'
+SHARED_QUERY_EMAIL_BODY = 'View the query at {query_url}'
 
 
 class ContextForm(forms.ModelForm):
@@ -244,13 +242,11 @@ class QueryForm(forms.ModelForm):
             title = SHARED_QUERY_EMAIL_TITLE.format(query_name=instance.name,
                                                     site_name=site.name)
 
+            body = SHARED_QUERY_EMAIL_BODY.format(query_url=query_url)
+
             if self.cleaned_data.get('message'):
-                body = self.cleaned_data.get('message')
-            else:
-                body = SHARED_QUERY_EMAIL_BODY.format(query_name=instance.name,
-                                                      site_name=site.name,
-                                                      site_url=site_url,
-                                                      query_url=query_url)
+                body = '{0}\n\n--\n{1}'.format(
+                    self.cleaned_data.get('message'), body)
 
             # Email and register all the new email addresses
             utils.send_mail(new_emails, title, body)

--- a/tests/cases/resources/tests/query.py
+++ b/tests/cases/resources/tests/query.py
@@ -195,7 +195,9 @@ class QueriesResourceTestCase(AuthenticatedBaseTestCase):
         self.assertEqual(len(mail.outbox), outbox_count + 1)
         self.assertEqual(mail.outbox[0].subject,
                          'example.com: POST Query has been shared with you!')
-        self.assertEqual(mail.outbox[0].body, 'THIS IS ONLY A TEST!')
+        self.assertEqual(mail.outbox[0].body,
+                         'THIS IS ONLY A TEST!\n\n--\nView the query at '
+                         'http://testserver/')
         self.assertSequenceEqual(
             mail.outbox[0].to, ['user1@email.com', 'user2@email.com'])
 


### PR DESCRIPTION
Fix #206.

Signed-off-by: Don Naegely naegelyd@gmail.com
