### PR TITLE
Update field stats resource to use bare aggregation calls

### DIFF
--- a/serrano/resources/field/stats.py
+++ b/serrano/resources/field/stats.py
@@ -35,30 +35,22 @@ class FieldStats(FieldBase):
         queryset = processor.get_queryset(request=request)
 
         if instance.simple_type == 'number':
-            # Since the call to max() returns an Aggregator object with the
-            # queryset stored internally, we don't pass the queryset to min()
-            # or avg() like we do when we call max() which is called on the
-            # instance itself not on an Aggregator like min() or avg() are
-            # called on.
-            stats = instance.max(queryset=queryset).min().avg()
+            resp = {
+                'max': instance.max(queryset=queryset),
+                'min': instance.min(queryset=queryset),
+                'avg': instance.avg(queryset=queryset)
+            }
         elif (instance.simple_type == 'date' or
               instance.simple_type == 'time' or
               instance.simple_type == 'datetime'):
-            # Since the call to max() returns an Aggregator object with the
-            # queryset stored internally, we don't pass the queryset to min()
-            # like we do when we call max() which is called on the instance
-            # itself not on an Aggregator like min() is called on.
-            stats = instance.max(queryset=queryset).min()
+            resp = {
+                'max': instance.max(queryset=queryset),
+                'min': instance.min(queryset=queryset)
+            }
         else:
-            stats = instance.count(queryset=queryset, distinct=True)
-
-        if stats is None:
-            resp = {}
-        else:
-            try:
-                resp = next(iter(stats))
-            except StopIteration:
-                resp = {}
+            resp = {
+                'count': instance.count(queryset=queryset, distinct=True)
+            }
 
         resp['_links'] = {
             'self': {


### PR DESCRIPTION
Fix #202, #177.

This resolves 2 of the current errors in the `2.4` branch by accounting for the fact that the aggregator calls(in Avocado 2.4+) now return raw values instead of an Aggregator object.

Signed-off-by: Don Naegely naegelyd@gmail.com
