### PR TITLE
Pass user to published() method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/cbmi/avocado.git@2.4
+git+git://github.com/cbmi/avocado.git
 django-preserialize>=1.0.7,<1.1.0
 restlib2>=0.4.2,<0.5.0
 python-memcached>=1.48

--- a/serrano/resources/concept.py
+++ b/serrano/resources/concept.py
@@ -105,7 +105,7 @@ class ConceptBase(ThrottledResource):
         if params.get('unpublished') and can_change_concept(request.user):
             return queryset
 
-        return queryset.published()
+        return queryset.published(user=request.user)
 
     def get_object(self, request, **kwargs):
         if not hasattr(request, 'instance'):

--- a/serrano/resources/field/base.py
+++ b/serrano/resources/field/base.py
@@ -92,7 +92,7 @@ class FieldBase(ThrottledResource):
         if params.get('unpublished') and can_change_field(request.user):
             return queryset
 
-        return queryset.published()
+        return queryset.published(user=request.user)
 
     def get_object(self, request, **kwargs):
         if not hasattr(request, 'instance'):


### PR DESCRIPTION
This ensures the django-guardian facilities in Avocado are applied.

Fix #220

Signed-off-by: Byron Ruth b@devel.io
