### PR TITLE
Pass request to call to get_iterable in preview endpoint

### DIFF
--- a/serrano/resources/preview.py
+++ b/serrano/resources/preview.py
@@ -51,7 +51,7 @@ class PreviewResource(BaseResource, PaginatorResource):
         offset = max(0, page.start_index() - 1)
 
         # Prepare the exporter and iterable
-        iterable = processor.get_iterable()
+        iterable = processor.get_iterable(request=request)
 
         # Build up the header keys.
         # TODO: This is flawed since it assumes the output columns


### PR DESCRIPTION
Fix #226.

This fixes the case where request-based query processors can cause
inconsistent results because get_queryset gets the request kwarg earlier
in the preview endpoint.

Signed-off-by: Don Naegely naegelyd@gmail.com
