### PR TITLE
Add support for processor param on Context/QueryStats endpoints

### DIFF
--- a/tests/cases/resources/tests/context.py
+++ b/tests/cases/resources/tests/context.py
@@ -155,6 +155,18 @@ class ContextStatsResourceTestCase(AuthenticatedBaseTestCase):
 
         self.assertEqual(json.loads(response.content)['count'], 6)
 
+    def test_processor(self):
+        cxt = DataContext(session=True, user=self.user)
+        cxt.save()
+
+        response = self.client.get('/api/contexts/1/stats/',
+                                   HTTP_ACCEPT='application/json')
+        self.assertEqual(json.loads(response.content)['count'], 6)
+
+        response = self.client.get('/api/contexts/1/stats/?processor=manager',
+                                   HTTP_ACCEPT='application/json')
+        self.assertEqual(json.loads(response.content)['count'], 1)
+
 
 class ContextsRevisionsResourceTestCase(AuthenticatedBaseTestCase):
     def test_get(self):

--- a/tests/cases/resources/tests/query.py
+++ b/tests/cases/resources/tests/query.py
@@ -489,6 +489,22 @@ class QueryStatsResourceTestCase(AuthenticatedBaseTestCase):
         self.assertEqual(data['distinct_count'], 6)
         self.assertEqual(data['record_count'], 6)
 
+    def test_processor(self):
+        query = DataQuery(session=True, user=self.user)
+        query.save()
+
+        response = self.client.get('/api/queries/1/stats/',
+                                   HTTP_ACCEPT='application/json')
+        data = json.loads(response.content)
+        self.assertEqual(data['distinct_count'], 6)
+        self.assertEqual(data['record_count'], 6)
+
+        response = self.client.get('/api/queries/1/stats/?processor=manager',
+                                   HTTP_ACCEPT='application/json')
+        data = json.loads(response.content)
+        self.assertEqual(data['distinct_count'], 1)
+        self.assertEqual(data['record_count'], 1)
+
 
 class EmailTestCase(BaseTestCase):
     subject = 'Email_Subject'


### PR DESCRIPTION
This mimics the behavior of #228 but adds the processor support to the new resources for retrieving the count. Counts are no longer being sent via the normal context and query resources as the count references have been removed from the ContextForm and QueryForm.

Signed-off-by: Don Naegely naegelyd@gmail.com
