### PR TITLE
Replace embedded _links with Link(-Template) header

### DIFF
--- a/serrano/conf/global_settings.py
+++ b/serrano/conf/global_settings.py
@@ -70,7 +70,7 @@ EXPORT_COOKIE_DATA = 'complete'
 
 # Provides a method for determining whether a field supports stats or not. By
 # default, stats are not supported on searchable fields. When this method
-# returns True, the stats URL will be included in the _links collection as
+# returns True, the stats URL will be included in the Link Header as
 # generated in the base field resource. Setting this to None will disable
 # stats for all fields.
 STATS_CAPABLE = lambda x: not x.searchable

--- a/serrano/links.py
+++ b/serrano/links.py
@@ -1,0 +1,156 @@
+from django.core.urlresolvers import reverse
+from urllib import unquote
+
+
+def _get_link(name, link, data=None):
+    """
+    Creates a link header field based on the supplied name, link, and data.
+
+    If the data is empty, then a link header field with a rel tag and link
+    value are generated. Otherwise, data is considered to contain keys and
+    values representing the available link header fields as noted in the RFC
+    here:
+
+        https://tools.ietf.org/html/rfc5988#section-5
+
+    When data is present, its content will be added after the link value and
+    rel fields.
+    """
+    if data is None:
+        return '<{0}>; rel="{1}"'.format(link, name)
+
+    header_data = []
+
+    for key, value in data.items():
+        header_data.append('{0}="{1}"'.format(key, value))
+
+    if header_data:
+        header_data = '; {0}'.format('; '.join(header_data))
+    else:
+        header_data = ''
+
+    return '<{0}>; rel="{1}"{2}'.format(link, name, header_data)
+
+
+def _get_links(data):
+    """
+    Returns a comma separated list of link header fields.
+
+    For more information on how the individual fields are generated, see the
+    _get_link(...) method above.
+    """
+    links = []
+
+    for name, value in data.items():
+        if isinstance(value, basestring):
+            links.append(_get_link(name, value))
+        else:
+            links.append(_get_link(name, value['link'], value['data']))
+
+    if links:
+        return ', '.join(links)
+
+    return links
+
+
+def reverse_tmpl(uri, name, params):
+    """
+    Returns an unquoted uri containing the reverse name with param replacement.
+
+    This methods does a number of things. If there were no params, all that
+    would happend would be that the name would be reversed, that reversed
+    name would be passed to the supplied uri method, and that unquoted uri
+    would be returned. When params are present, we will modify the reversed
+    name.
+
+    Params should be a dictionary in the following form:
+
+        {
+            url_param: (type, alias),
+            ...
+        }
+
+    So, let's consider the url for retrieving a single view:
+
+        url(r'^(?P<pk>\d+)/$', single_resource, name='single')
+
+    Then we would constructs params as:
+
+        {
+            'pk': (int, 'id')
+        }
+
+    Which instructs this method that the pk url param is an integer and should
+    be replaced in the final uri with `{id}`. The types supported by this
+    method are:
+
+        (complex, float, int, long, str)
+
+    Which should cover all the cases we could possibly see in the URL. Also,
+    these happen to be all the cases we can safely convert an int to. This is
+    important because we use integers as placeholders when reversing the URL
+    and then we replace those integers with the aliases after all the
+    reversals are done. As noted below, this has the limitation of only
+    supporting 10 params. The reason for this limitation is in the replacement.
+    Let's say we had 11 params then the 11th param would take the placeholder
+    10. When we go to replace, we might try to replace 0 and 1 before 10 which
+    means that the 1 and 0 in 10 might be replaced before 10 itself is replaced
+    which would obviously return a malformed uri. This is acceptable in our
+    case as we don't have any urls with more than 2 params so until there is
+    a strong use case for supporting 11+ url params, this should suffice.
+
+    The unquoting occurs becuase we don't want %7B and %7D for { and }
+    respectively in the returned url. This will occur because the replacement
+    is occuring before the call to uri which will quote those characters. If
+    for nothing else, this increases readability of the URLs and makes the
+    URLs consistent for the client.
+    """
+
+    kwargs = {}
+    variables = {}
+    supported_types = (complex, float, int, long, str)
+
+    # NOTE: It is known that this method will only support 10 replacements
+    # for values [0-9] before there would be "collisions" when replacing but
+    # we have now use cases for URLs with 10 or more url parameters so this
+    # should be safe for our uses and we can adapt this should that case ever
+    # come to exist.
+    param_num = 0
+    for key, type_alias in params.items():
+        type = type_alias[0]
+        alias = type_alias[1]
+
+        if type not in supported_types:
+            raise ValueError(
+                'Cannot reverse template with type {0}. The supported types '
+                'are {1}.'.format(type, supported_types))
+
+        value = type(param_num)
+        variables[str(value)] = '{{{0}}}'.format(alias)
+        kwargs[key] = value
+
+        param_num += 1
+
+    url = reverse(name, kwargs=kwargs)
+    for val, var in variables.items():
+        url = url.replace(val, var)
+
+    return unquote(uri(url))
+
+
+def patch_response(request, response, links, link_templates):
+    """
+    Sets the Link and Link-Template header fields on the response.
+
+    These fields will only be set if the supplied link and link_templates are
+    non-empty and those header fields are not already set on the supplied
+    response object.
+    """
+
+    if 'Link' not in response and links:
+        response['Link'] = _get_links(links)
+
+    if 'Link-Template' not in response and link_templates:
+        response['Link-Template'] = _get_links(link_templates)
+
+    return response

--- a/serrano/resources/__init__.py
+++ b/serrano/resources/__init__.py
@@ -22,58 +22,34 @@ class Root(BaseResource):
         if request.method != 'POST':
             return super(Root, self).is_unauthorized(request, *args, **kwargs)
 
-    def get(self, request):
+    def get_links(self, request):
         uri = request.build_absolute_uri
 
-        data = {
-            'title': 'Serrano Hypermedia API',
-            'version': API_VERSION,
-            '_links': {
-                'self': {
-                    'href': uri(reverse('serrano:root')),
-                },
-                'categories': {
-                    'href': uri(reverse('serrano:categories')),
-                },
-                'fields': {
-                    'href': uri(reverse('serrano:fields')),
-                },
-                'concepts': {
-                    'href': uri(reverse('serrano:concepts')),
-                },
-                'contexts': {
-                    'href': uri(reverse('serrano:contexts:active')),
-                },
-                'views': {
-                    'href': uri(reverse('serrano:views:active')),
-                },
-                'queries': {
-                    'href': uri(reverse('serrano:queries:active')),
-                },
-                'public_queries': {
-                    'href': uri(reverse('serrano:queries:public')),
-                },
-                'preview': {
-                    'href': uri(reverse('serrano:data:preview')),
-                },
-                'exporter': {
-                    'href': uri(reverse('serrano:data:exporter')),
-                },
-                'ping': {
-                    'href': uri(reverse('serrano:ping')),
-                },
-                'stats': {
-                    'href': uri(reverse('serrano:stats:root')),
-                },
-            }
+        links = {
+            'self': uri(reverse('serrano:root')),
+            'categories': uri(reverse('serrano:categories')),
+            'fields': uri(reverse('serrano:fields')),
+            'concepts': uri(reverse('serrano:concepts')),
+            'contexts': uri(reverse('serrano:contexts:active')),
+            'views': uri(reverse('serrano:views:active')),
+            'queries': uri(reverse('serrano:queries:active')),
+            'public_queries': uri(reverse('serrano:queries:public')),
+            'preview': uri(reverse('serrano:data:preview')),
+            'exporter': uri(reverse('serrano:data:exporter')),
+            'ping': uri(reverse('serrano:ping')),
+            'stats': uri(reverse('serrano:stats:root')),
         }
 
         if dep_supported('objectset'):
-            data['_links']['sets'] = {
-                'href': uri(reverse('serrano:sets:root')),
-            }
+            links['sets'] = uri(reverse('serrano:sets:root'))
 
-        return data
+        return links
+
+    def get(self, request):
+        return {
+            'title': 'Serrano Hypermedia API',
+            'version': API_VERSION,
+        }
 
     def post(self, request):
         username = request.data.get('username')

--- a/serrano/resources/base.py
+++ b/serrano/resources/base.py
@@ -8,6 +8,7 @@ from serrano.conf import settings
 from django.contrib.auth import authenticate, login
 from ..tokens import get_request_token
 from .. import cors
+from .. import links
 
 __all__ = ('BaseResource', 'ThrottledResource')
 
@@ -205,8 +206,22 @@ class BaseResource(Resource):
     def process_response(self, request, response):
         response = super(BaseResource, self).process_response(
             request, response)
+
         response = cors.patch_response(request, response, self.allowed_methods)
+
+        response = links.patch_response(
+            request, response, self.get_links(request),
+            self.get_link_templates(request))
+
         return response
+
+    def get_links(self, request):
+        "Returns the links to include in the headers of responses"
+        return {}
+
+    def get_link_templates(self, request):
+        "Returns the link templates to include in the headers of responses"
+        return {}
 
     def get_params(self, request):
         "Returns cleaned set of GET parameters."

--- a/serrano/resources/exporter.py
+++ b/serrano/resources/exporter.py
@@ -16,26 +16,33 @@ EXPORT_TYPES = zip(*exporters.choices)[0]
 
 
 class ExporterRootResource(BaseResource):
-    def get(self, request):
+    def get_links(self, request):
         uri = request.build_absolute_uri
 
-        resp = {
-            'title': 'Serrano Exporter Endpoints',
-            'version': API_VERSION,
-            '_links': {
-                'self': {
-                    'href': uri(reverse('serrano:data:exporter')),
-                },
-            }
+        links = {
+            'self': uri(reverse('serrano:data:exporter')),
         }
 
         for export_type in EXPORT_TYPES:
-            resp['_links'][export_type] = {
-                'href': uri(reverse('serrano:data:exporter',
-                                    kwargs={'export_type': export_type})),
-                'title': exporters.get(export_type).short_name,
-                'description': exporters.get(export_type).long_name,
+            links[export_type] = {
+                'link': uri(reverse(
+                    'serrano:data:exporter',
+                    kwargs={'export_type': export_type}
+                )),
+                'data': {
+                    'title': exporters.get(export_type).short_name,
+                    'description': exporters.get(export_type).long_name,
+                }
             }
+
+        return links
+
+    def get(self, request):
+        resp = {
+            'title': 'Serrano Exporter Endpoints',
+            'version': API_VERSION
+        }
+
         return resp
 
 

--- a/serrano/resources/field/dist.py
+++ b/serrano/resources/field/dist.py
@@ -1,8 +1,9 @@
 from django.utils.encoding import smart_unicode
+from restlib2.http import codes
 from restlib2.params import Parametizer, StrParam, BoolParam
 from avocado.events import usage
 from avocado.query import pipeline
-from .base import FieldBase
+from .base import FieldBase, is_field_orphaned
 
 
 class FieldDistParametizer(Parametizer):
@@ -17,6 +18,13 @@ class FieldDistribution(FieldBase):
 
     def get(self, request, pk):
         instance = self.get_object(request, pk=pk)
+
+        if is_field_orphaned(instance):
+            data = {
+                'message': 'Orphaned fields do not support distribution calls.'
+            }
+            return self.render(
+                request, data, status=codes.unprocessable_entity)
 
         params = self.get_params(request)
 

--- a/serrano/resources/pagination.py
+++ b/serrano/resources/pagination.py
@@ -58,28 +58,17 @@ class PaginatorResource(Resource):
         path_format = '{0}?{1}'.format(path, '&'.join(pairs))
 
         links = {
-            'self': {
-                'href': uri(path_format.format(page=page.number,
-                                               limit=limit)),
-            },
-            'base': {
-                'href': uri(path),
-            }
+            'self': uri(path_format.format(page=page.number, limit=limit)),
+            'base': uri(path),
         }
 
         if page.has_previous():
-            links['prev'] = {
-                'href': uri(
-                    path_format.format(page=page.previous_page_number(),
-                                       limit=limit)),
-            }
+            links['prev'] = uri(path_format.format(
+                page=page.previous_page_number(), limit=limit))
 
         if page.has_next():
-            links['next'] = {
-                'href': uri(
-                    path_format.format(page=page.next_page_number(),
-                                       limit=limit)),
-            }
+            links['next'] = uri(path_format.format(
+                page=page.next_page_number(), limit=limit))
 
         return links
 

--- a/serrano/resources/preview.py
+++ b/serrano/resources/preview.py
@@ -10,6 +10,7 @@ from avocado.export import HTMLExporter
 from restlib2.params import StrParam
 from .base import BaseResource
 from .pagination import PaginatorResource, PaginatorParametizer
+from ..links import patch_response
 
 
 class PreviewParametizer(PaginatorParametizer):
@@ -96,21 +97,21 @@ class PreviewResource(BaseResource, PaginatorResource):
         model_name = opts.verbose_name.format()
         model_name_plural = opts.verbose_name_plural.format()
 
-        resp = self.get_page_response(request, paginator, page)
+        data = self.get_page_response(request, paginator, page)
 
-        path = reverse('serrano:data:preview')
-        links = self.get_page_links(request, path, page, extra=params)
-
-        resp.update({
+        data.update({
             'keys': header,
             'items': objects,
             'item_name': model_name,
             'item_name_plural': model_name_plural,
-            'item_count': paginator.count,
-            '_links': links,
+            'item_count': paginator.count
         })
 
-        return resp
+        path = reverse('serrano:data:preview')
+        links = self.get_page_links(request, path, page, extra=params)
+        response = self.render(request, content=data)
+
+        return patch_response(request, response, links, {})
 
     # POST mimics GET to support sending large request bodies for on-the-fly
     # context and view data.

--- a/serrano/resources/sets.py
+++ b/serrano/resources/sets.py
@@ -114,18 +114,24 @@ for config in settings.OBJECT_SETS:
 class SetsRootResource(BaseResource):
     object_set_options = tuple(object_set_options)
 
-    def get(self, request):
+    def get_links(self, request):
         uri = request.build_absolute_uri
-        data = []
 
+        links = {}
         for options in self.object_set_options:
             reverses = options['url_reverse_names']
 
+            options['label'] = uri(reverse(reverses['sets']))
+
+        return links
+
+    def get(self, request):
+
+        data = []
+
+        for options in self.object_set_options:
             data.append({
                 'label': options['label'],
-                '_links': {
-                    'self': uri(reverse(reverses['sets'])),
-                }
             })
 
         return data

--- a/serrano/resources/stats.py
+++ b/serrano/resources/stats.py
@@ -11,19 +11,17 @@ from .base import BaseResource, ThrottledResource
 
 
 class StatsResource(BaseResource):
-    def get(self, request):
+    def get_links(self, request):
         uri = request.build_absolute_uri
 
         return {
+            'self': uri(reverse('serrano:stats:root')),
+            'counts': uri(reverse('serrano:stats:counts'))
+        }
+
+    def get(self, request):
+        return {
             'title': 'Serrano Stats Endpoint',
-            '_links': {
-                'self': {
-                    'href': uri(reverse('serrano:stats:root')),
-                },
-                'counts': {
-                    'href': uri(reverse('serrano:stats:counts')),
-                },
-            }
         }
 
 

--- a/serrano/resources/view.py
+++ b/serrano/resources/view.py
@@ -1,8 +1,6 @@
-import functools
 import logging
 from datetime import datetime
 from django.conf.urls import patterns, url
-from django.core.urlresolvers import reverse
 from django.views.decorators.cache import never_cache
 from restlib2.http import codes
 from preserialize.serialize import serialize
@@ -13,18 +11,9 @@ from .base import ThrottledResource
 from .history import RevisionsResource, ObjectRevisionsResource, \
     ObjectRevisionResource
 from . import templates
+from ..links import reverse_tmpl
 
 log = logging.getLogger(__name__)
-
-
-def view_posthook(instance, data, request):
-    uri = request.build_absolute_uri
-    data['_links'] = {
-        'self': {
-            'href': uri(reverse('serrano:views:single', args=[instance.pk])),
-        }
-    }
-    return data
 
 
 class ViewBase(ThrottledResource):
@@ -34,11 +23,19 @@ class ViewBase(ThrottledResource):
     model = DataView
     template = templates.View
 
+    def get_link_templates(self, request):
+        uri = request.build_absolute_uri
+
+        return {
+            'view': reverse_tmpl(
+                uri, 'serrano:views:single', {'pk': (int, 'id')})
+        }
+
     def prepare(self, request, instance, template=None):
         if template is None:
             template = self.template
-        posthook = functools.partial(view_posthook, request=request)
-        return serialize(instance, posthook=posthook, **template)
+
+        return serialize(instance, **template)
 
     def get_queryset(self, request, **kwargs):
         "Constructs a QuerySet for this user or session."

--- a/tests/cases/resources/tests/base.py
+++ b/tests/cases/resources/tests/base.py
@@ -39,26 +39,24 @@ class RootResourceTestCase(TestCase):
         response = self.client.get('/api/', HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, codes.ok)
         self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response['Link'], (
+            '<http://testserver/api/data/export/>; rel="exporter", '
+            '<http://testserver/api/views/>; rel="views", '
+            '<http://testserver/api/concepts/>; rel="concepts", '
+            '<http://testserver/api/stats/>; rel="stats", '
+            '<http://testserver/api/categories/>; rel="categories", '
+            '<http://testserver/api/queries/public/>; rel="public_queries", '
+            '<http://testserver/api/sets/>; rel="sets", '
+            '<http://testserver/api/contexts/>; rel="contexts", '
+            '<http://testserver/api/fields/>; rel="fields", '
+            '<http://testserver/api/>; rel="self", '
+            '<http://testserver/api/ping/>; rel="ping", '
+            '<http://testserver/api/queries/>; rel="queries", '
+            '<http://testserver/api/data/preview/>; rel="preview"'
+        ))
         self.assertEqual(json.loads(response.content), {
             'title': 'Serrano Hypermedia API',
             'version': API_VERSION,
-            '_links': {
-                'exporter': {'href': 'http://testserver/api/data/export/'},
-                'views': {'href': 'http://testserver/api/views/'},
-                'contexts': {'href': 'http://testserver/api/contexts/'},
-                'queries': {'href': 'http://testserver/api/queries/'},
-                'public_queries': {
-                    'href': 'http://testserver/api/queries/public/'
-                },
-                'fields': {'href': 'http://testserver/api/fields/'},
-                'categories': {'href': 'http://testserver/api/categories/'},
-                'self': {'href': 'http://testserver/api/'},
-                'concepts': {'href': 'http://testserver/api/concepts/'},
-                'preview': {'href': 'http://testserver/api/data/preview/'},
-                'sets': {'href': 'http://testserver/api/sets/'},
-                'ping': {'href': 'http://testserver/api/ping/'},
-                'stats': {'href': 'http://testserver/api/stats/'},
-            },
         })
 
     @override_settings(SERRANO_AUTH_REQUIRED=True)
@@ -218,7 +216,7 @@ class RevisionResourceTestCase(AuthenticatedBaseTestCase):
         revision = json.loads(response.content)[0]
         self.assertEqual(revision['id'], 1)
         self.assertEqual(revision['object_id'], 1)
-        self.assertTrue('_links' in revision)
+        self.assertTrue(response['Link-Template'])
         self.assertFalse('content_type' in revision)
 
 

--- a/tests/cases/resources/tests/category.py
+++ b/tests/cases/resources/tests/category.py
@@ -30,6 +30,10 @@ class CategoryResourceTestCase(BaseTestCase):
                                    HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, codes.ok)
         self.assertTrue(json.loads(response.content))
+        self.assertEqual(response['Link-Template'], (
+            '<http://testserver/api/categories/{id}/>; rel="category", '
+            '<http://testserver/api/categories/{parent_id}/>; rel="parent"'
+        ))
         self.assertTrue(Log.objects.filter(event='read', object_id=1).exists())
 
     def test_get_privileged(self):

--- a/tests/cases/resources/tests/concept.py
+++ b/tests/cases/resources/tests/concept.py
@@ -39,6 +39,11 @@ class ConceptResourceTestCase(BaseTestCase):
         self.assertEqual(response.status_code, codes.ok)
         self.assertEqual(len(json.loads(response.content)), 2)
 
+        self.assertEqual(response['Link-Template'], (
+            '<http://testserver/api/concepts/{id}/fields/>; rel="concept-fields", '   # noqa
+            '<http://testserver/api/concepts/{id}/>; rel="concept"'
+        ))
+
     def test_get_all_category_sort(self):
         # Create some temporary concepts and categories.
         cat1 = DataCategory(name='Category1', order=1.0, published=True)

--- a/tests/cases/resources/tests/context.py
+++ b/tests/cases/resources/tests/context.py
@@ -9,6 +9,10 @@ class ContextResourceTestCase(AuthenticatedBaseTestCase):
         response = self.client.get('/api/contexts/',
                                    HTTP_ACCEPT='application/json')
         self.assertFalse(json.loads(response.content))
+        self.assertEqual(response['Link-Template'], (
+            '<http://testserver/api/contexts/{id}/stats/>; rel="stats", '
+            '<http://testserver/api/contexts/{id}/>; rel="context"'
+        ))
 
     def test_get_all_default(self):
         cxt = DataContext(template=True, default=True, json={})

--- a/tests/cases/resources/tests/exporter.py
+++ b/tests/cases/resources/tests/exporter.py
@@ -12,42 +12,23 @@ class ExporterResourceTestCase(TestCase):
         self.assertEqual(response.status_code, codes.ok)
         self.assertEqual(response['Content-Type'], 'application/json')
 
-        expectedResponse = {
+        self.assertEqual(json.loads(response.content), {
             'title': 'Serrano Exporter Endpoints',
-            'version': API_VERSION,
-            '_links': {
-                'self': {'href': 'http://testserver/api/data/export/'},
-                'json': {
-                    'href': 'http://testserver/api/data/export/json/',
-                    'description': 'JavaScript Object Notation (JSON)',
-                    'title': 'JSON'
-                },
-                'r': {
-                    'href': 'http://testserver/api/data/export/r/',
-                    'description': 'R Programming Language',
-                    'title': 'R'
-                },
-                'sas': {
-                    'href': 'http://testserver/api/data/export/sas/',
-                    'description': 'Statistical Analysis System (SAS)',
-                    'title': 'SAS'
-                },
-                'csv': {
-                    'href': 'http://testserver/api/data/export/csv/',
-                    'description': 'Comma-Separated Values (CSV)',
-                    'title': 'CSV'
-                }
-            },
-        }
+            'version': API_VERSION
+        })
+
+        expected_links = (
+            '<http://testserver/api/data/export/sas/>; rel="sas"; description="Statistical Analysis System (SAS)"; title="SAS", '  # noqa
+            '<http://testserver/api/data/export/>; rel="self", '
+            '<http://testserver/api/data/export/csv/>; rel="csv"; description="Comma-Separated Values (CSV)"; title="CSV", '  # noqa
+            '<http://testserver/api/data/export/r/>; rel="r"; description="R Programming Language"; title="R", '  # noqa
+            '<http://testserver/api/data/export/json/>; rel="json"; description="JavaScript Object Notation (JSON)"; title="JSON"'  # noqa
+        )
 
         if OPTIONAL_DEPS['openpyxl']:
-            expectedResponse['_links']['excel'] = {
-                'href': 'http://testserver/api/data/export/excel/',
-                'description': 'Microsoft Excel 2007 Format',
-                'title': 'Excel'
-            }
+            expected_links += ', <http://testserver/api/data/export/excel/>; rel="excel"; description="Microsoft Excel 2007 Format"; title="Excel"'  # noqa
 
-        self.assertEqual(json.loads(response.content), expectedResponse)
+        self.assertEqual(response['Link'], expected_links)
 
     def test_export_bad_type(self):
         response = self.client.get('/api/data/export/bad_type/')

--- a/tests/cases/resources/tests/preview.py
+++ b/tests/cases/resources/tests/preview.py
@@ -37,15 +37,6 @@ class PreviewResourceTestCase(TestCase):
         self.assertEqual(response.status_code, codes.ok)
         self.assertEqual(response['Content-Type'], 'application/json')
         self.assertEqual(json.loads(response.content), {
-            '_links': {
-                'self': {
-                    'href': 'http://testserver/api/data/preview/?'
-                            'limit=20&page=1',
-                },
-                'base': {
-                    'href': 'http://testserver/api/data/preview/',
-                }
-            },
             'keys': [],
             'count': 0,
             'item_count': 0,
@@ -56,6 +47,10 @@ class PreviewResourceTestCase(TestCase):
             'num_pages': 1,
             'limit': 20,
         })
+        self.assertEqual(response['Link'], (
+            '<http://testserver/api/data/preview/?limit=20&page=1>; rel="self", '   # noqa
+            '<http://testserver/api/data/preview/>; rel="base"'
+        ))
 
     def test_get_with_user(self):
         self.user = User.objects.create_user(username='test', password='test')
@@ -66,15 +61,6 @@ class PreviewResourceTestCase(TestCase):
         self.assertEqual(response.status_code, codes.ok)
         self.assertEqual(response['Content-Type'], 'application/json')
         self.assertEqual(json.loads(response.content), {
-            '_links': {
-                'self': {
-                    'href': 'http://testserver/api/data/preview/?'
-                            'limit=20&page=1',
-                },
-                'base': {
-                    'href': 'http://testserver/api/data/preview/',
-                }
-            },
             'keys': [],
             'count': 0,
             'item_count': 0,
@@ -85,3 +71,7 @@ class PreviewResourceTestCase(TestCase):
             'num_pages': 1,
             'limit': 20,
         })
+        self.assertEqual(response['Link'], (
+            '<http://testserver/api/data/preview/?limit=20&page=1>; rel="self", '   # noqa
+            '<http://testserver/api/data/preview/>; rel="base"'
+        ))

--- a/tests/cases/resources/tests/stats.py
+++ b/tests/cases/resources/tests/stats.py
@@ -14,7 +14,10 @@ class StatsResourceTestCase(BaseTestCase):
                                    HTTP_ACCEPT='application/json')
 
         self.assertEqual(response.status_code, codes.ok)
-        self.assertTrue('_links' in json.loads(response.content))
+        self.assertEqual(response['Link'], (
+            '<http://testserver/api/stats/>; rel="self", '
+            '<http://testserver/api/stats/counts/>; rel="counts"'
+        ))
 
 
 class CountStatsResourceTestCase(BaseTestCase):

--- a/tests/cases/resources/tests/view.py
+++ b/tests/cases/resources/tests/view.py
@@ -14,6 +14,11 @@ class ViewResourceTestCase(AuthenticatedBaseTestCase):
                                    HTTP_ACCEPT='application/json')
         self.assertFalse(json.loads(response.content))
 
+        self.assertEqual(
+            response['Link-Template'],
+            '<http://testserver/api/views/{id}/>; rel="view"'
+        )
+
     def test_get_all_default(self):
         view = DataView(template=True, default=True, json=[])
         view.save()
@@ -239,12 +244,7 @@ class ViewsRevisionsResourceTestCase(AuthenticatedBaseTestCase):
         self.assertEqual(response.status_code, codes.ok)
         revision_view = json.loads(response.content)
 
-        # We can't just compare the objects directly to one another because the
-        # object returned from the call to /api/views/1/ will have '_links'
-        # while the embeded object will not because the link location is
-        # different for Revisions.
-        for key in embed_revision['object']:
-            self.assertEqual(revision_view[key], embed_revision['object'][key])
+        self.assertEqual(revision_view, embed_revision['object'])
 
 
 class ViewRevisionsResourceTestCase(AuthenticatedBaseTestCase):


### PR DESCRIPTION
Fix #205. As noted in the conversation on #205 itself, this will take some updating by existing clients to read and process the Link and Link-Template sections from the header. The Link portion should be a very straightforward update as it behaves exactly as `_links` did but some more care will need to be taken when processing the Link-Template headers as they provide templates of URLs that will need to be adapted to individual objects based on id or other field replacements.

Signed-off-by: Don Naegely naegelyd@gmail.com
