### PR TITLE
Include a flag in fields to indicate stats support

### DIFF
--- a/serrano/resources/field/base.py
+++ b/serrano/resources/field/base.py
@@ -6,6 +6,7 @@ from restlib2.params import Parametizer, StrParam, BoolParam, IntParam
 from avocado.conf import OPTIONAL_DEPS
 from avocado.models import DataField
 from avocado.events import usage
+from serrano.conf import settings
 from ..base import ThrottledResource
 from .. import templates
 from ...links import reverse_tmpl
@@ -33,6 +34,12 @@ def field_posthook(instance, data, request):
     # supplementary resources.
     if is_field_orphaned(instance):
         data['orphaned'] = True
+
+    # Add a flag indicating the field supports stats so clients know it is
+    # OK to call that endpoint.
+    stats_capable = settings.STATS_CAPABLE
+    if stats_capable and stats_capable(instance):
+        data['stats_capable'] = True
 
     return data
 

--- a/tests/cases/resources/tests/field.py
+++ b/tests/cases/resources/tests/field.py
@@ -26,6 +26,12 @@ class FieldResourceTestCase(BaseTestCase):
         # Initially, the default stats_capable check will be used that allows
         # for stats on all non-searchable fields so we will expect that the
         # stats endpoint will return normally.
+        response = self.client.get('/api/fields/2/',
+                                   HTTP_ACCEPT='applicaton/json')
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, codes.ok)
+        self.assertTrue('stats_capable' in content)
+
         response = self.client.get('/api/fields/2/stats/',
                                    HTTP_ACCEPT='applicaton/json')
         self.assertEqual(response.status_code, codes.ok)
@@ -37,6 +43,12 @@ class FieldResourceTestCase(BaseTestCase):
         # Now, overriding that setting so that this field is not
         # "stats_capable" should 'disable' the stats endpoint for that field.
         with self.settings(SERRANO_STATS_CAPABLE=lambda x: x.id != 2):
+            response = self.client.get('/api/fields/2/',
+                                       HTTP_ACCEPT='applicaton/json')
+            content = json.loads(response.content)
+            self.assertEqual(response.status_code, codes.ok)
+            self.assertFalse('stats_capable' in content)
+
             response = self.client.get('/api/fields/2/stats/',
                                        HTTP_ACCEPT='applicaton/json')
             self.assertEqual(response.status_code, codes.unprocessable_entity)


### PR DESCRIPTION
Previously, this was done by just not sending back the stats link but we are using link templates now at the collection level so without this flag, clients will think all fields are stats capable.

Signed-off-by: Don Naegely naegelyd@gmail.com
