### PR TITLE
Always embed basic field data in concept resource responses

### DIFF
--- a/serrano/resources/templates.py
+++ b/serrano/resources/templates.py
@@ -45,16 +45,6 @@ Concept = {
     'allow_missing': True,
 }
 
-ConceptField = {
-    'fields': ['alt_name', 'alt_plural_name', 'order'],
-    'aliases': {
-        'alt_name': '__unicode__',
-        'alt_plural_name': 'get_plural_name',
-    },
-    'allow_missing': True,
-}
-
-
 Context = {
     'exclude': ['user', 'session_key'],
     'allow_missing': True,


### PR DESCRIPTION
This also removes the need for the ConceptFields resource which has also been removed in this commit.

Signed-off-by: Don Naegely naegelyd@gmail.com
