### PR TITLE
Added @csrf_protect decorator from django.views.decorators.csrf to resol...

### DIFF
--- a/serrano/tokens.py
+++ b/serrano/tokens.py
@@ -6,6 +6,9 @@ from random import SystemRandom
 from django.conf import settings as django_settings
 from django.utils.http import int_to_base36, base36_to_int
 from serrano.conf import settings
+#from django.views.decorators.cache import cache_page
+from django.views.decorators.csrf import csrf_protect
+
 
 # Hex characters
 HEX_CHARS = string.lowercase[:6] + string.digits
@@ -109,7 +112,7 @@ class TokenGenerator(object):
 
 token_generator = TokenGenerator()
 
-
+@csrf_protect
 def get_request_token(request):
     "Attempts to retrieve a token from the request."
     if 'token' in request.REQUEST:


### PR DESCRIPTION
 I initially got this error  when trying to Apply filter.:
[24/Nov/2014 16:17:19] "POST /api/contexts/ HTTP/1.1" 403 1147

This was the page loaded in devtools.
![image](https://cloud.githubusercontent.com/assets/3758548/5175217/8f8a3b5e-7406-11e4-827b-be7eae5ce050.png)

…Following the docs referenced ultimately led me here (click around and scroll down a bit. Docs below are for Django 1.5.

![image](https://cloud.githubusercontent.com/assets/3758548/5175221/9980e374-7406-11e4-88c2-c3eb01f072b3.png)

For whatever reason, the app wasn’t sending the token with its POST requests:

Before:
![image](https://cloud.githubusercontent.com/assets/3758548/5175230/bae3cfae-7406-11e4-8d3e-0aa036fa6f36.png)

I traced the origin of the post requests to serrano, in tokens.py file (serrano.tokens)
![pastedgraphic-9](https://cloud.githubusercontent.com/assets/3758548/5175240/ce08a370-7406-11e4-9f68-63e51a047292.png)

Before:

That matched the error described in the django docs above. I added the decorator:

**After:**
![pastedgraphic-6](https://cloud.githubusercontent.com/assets/3758548/5175265/f1008abe-7406-11e4-8cd7-ff5f7945639a.png)

And the problem was resolved.

![pastedgraphic-8](https://cloud.githubusercontent.com/assets/3758548/5175349/af213fde-7407-11e4-9fc8-39d8fbb8f182.png)

![image](https://cloud.githubusercontent.com/assets/3758548/5175282/19a60d5e-7407-11e4-8203-68216cbab71f.png)
