### PR TITLE
Revert "Remove metadata from preview endpoint response"

### DIFF
--- a/serrano/resources/preview.py
+++ b/serrano/resources/preview.py
@@ -35,23 +35,23 @@ class PreviewResource(BaseResource, PaginatorResource):
         limit = params.get('limit')
         tree = params.get('tree')
 
-        # Get the request's view and context.
+        # Get the request's view and context
         view = self.get_view(request)
         context = self.get_context(request)
 
-        # Initialize a query processor.
+        # Initialize a query processor
         QueryProcessor = pipeline.query_processors[params['processor']]
         processor = QueryProcessor(context=context, view=view, tree=tree)
 
-        # Build a queryset for pagination and other downstream use.
+        # Build a queryset for pagination and other downstream use
         queryset = processor.get_queryset(request=request)
 
-        # Get paginator and page.
+        # Get paginator and page
         paginator = self.get_paginator(queryset, limit=limit)
         page = paginator.page(page)
         offset = max(0, page.start_index() - 1)
 
-        # Prepare the exporter and iterable.
+        # Prepare the exporter and iterable
         iterable = processor.get_iterable(request=request)
 
         # Build up the header keys.
@@ -69,14 +69,14 @@ class PreviewResource(BaseResource, PaginatorResource):
                 obj['direction'] = ordering[concept.id]
             header.append(obj)
 
-        # Prepare an HTMLExporter.
+        # Prepare an HTMLExporter
         exporter = processor.get_exporter(HTMLExporter)
         pk_name = queryset.model._meta.pk.name
 
         objects = []
 
         # 0 limit means all for pagination, however the read method requires
-        # an explicit limit or None.
+        # an explicit limit or None
         read_limit = limit or None
 
         for row in exporter.read(iterable, request=request, offset=offset,
@@ -92,9 +92,24 @@ class PreviewResource(BaseResource, PaginatorResource):
 
             objects.append({'pk': pk, 'values': values})
 
+        # Various model options
+        opts = queryset.model._meta
+        model_name = opts.verbose_name.format()
+        model_name_plural = opts.verbose_name_plural.format()
+
+        data = self.get_page_response(request, paginator, page)
+
+        data.update({
+            'keys': header,
+            'items': objects,
+            'item_name': model_name,
+            'item_name_plural': model_name_plural,
+            'item_count': paginator.count
+        })
+
         path = reverse('serrano:data:preview')
         links = self.get_page_links(request, path, page, extra=params)
-        response = self.render(request, content=objects)
+        response = self.render(request, content=data)
 
         return patch_response(request, response, links, {})
 

--- a/tests/cases/resources/tests/preview.py
+++ b/tests/cases/resources/tests/preview.py
@@ -10,7 +10,8 @@ class PreviewResourceProcessorTestCase(BaseTestCase):
         response = self.client.get('/api/data/preview/',
                                    HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, codes.ok)
-        self.assertEqual(len(json.loads(response.content)), 6)
+        content = json.loads(response.content)
+        self.assertEqual(content['item_count'], 6)
 
         # The Parametizer cleaning process should set this to the default
         # value if the processor is not in the list of choices which, in our
@@ -19,12 +20,14 @@ class PreviewResourceProcessorTestCase(BaseTestCase):
         response = self.client.get('/api/data/preview/?processor=INVALID',
                                    HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, codes.ok)
-        self.assertEqual(len(json.loads(response.content)), 6)
+        content = json.loads(response.content)
+        self.assertEqual(content['item_count'], 6)
 
         response = self.client.get('/api/data/preview/?processor=manager',
                                    HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, codes.ok)
-        self.assertEqual(len(json.loads(response.content)), 1)
+        content = json.loads(response.content)
+        self.assertEqual(content['item_count'], 1)
 
 
 class PreviewResourceTestCase(TestCase):
@@ -33,7 +36,17 @@ class PreviewResourceTestCase(TestCase):
                                    HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, codes.ok)
         self.assertEqual(response['Content-Type'], 'application/json')
-        self.assertEqual(json.loads(response.content), [])
+        self.assertEqual(json.loads(response.content), {
+            'keys': [],
+            'count': 0,
+            'item_count': 0,
+            'item_name': 'employee',
+            'item_name_plural': 'employees',
+            'items': [],
+            'page_num': 1,
+            'num_pages': 1,
+            'limit': 20,
+        })
         self.assertEqual(response['Link'], (
             '<http://testserver/api/data/preview/?limit=20&page=1>; rel="self", '   # noqa
             '<http://testserver/api/data/preview/>; rel="base", '
@@ -49,7 +62,17 @@ class PreviewResourceTestCase(TestCase):
                                    HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, codes.ok)
         self.assertEqual(response['Content-Type'], 'application/json')
-        self.assertEqual(json.loads(response.content), [])
+        self.assertEqual(json.loads(response.content), {
+            'keys': [],
+            'count': 0,
+            'item_count': 0,
+            'item_name': 'employee',
+            'item_name_plural': 'employees',
+            'items': [],
+            'page_num': 1,
+            'num_pages': 1,
+            'limit': 20,
+        })
         self.assertEqual(response['Link'], (
             '<http://testserver/api/data/preview/?limit=20&page=1>; rel="self", '   # noqa
             '<http://testserver/api/data/preview/>; rel="base", '


### PR DESCRIPTION
Reverts cbmi/serrano#238. The removal of this information absolutely crushes Cilantro. Until more time and planning can be dedicated to making Cilantro(read structs/paginator) work without this metadata it will remain in the response of the preview endpoint. 
