### PR TITLE
Add support for the tree parameter on field and concept resources

### DIFF
--- a/serrano/resources/field/dist.py
+++ b/serrano/resources/field/dist.py
@@ -1,6 +1,7 @@
 from django.utils.encoding import smart_unicode
 from restlib2.http import codes
 from restlib2.params import Parametizer, StrParam, BoolParam
+from modeltree.tree import MODELTREE_DEFAULT_ALIAS, trees
 from avocado.events import usage
 from avocado.query import pipeline
 from .base import FieldBase, is_field_orphaned
@@ -8,6 +9,7 @@ from .base import FieldBase, is_field_orphaned
 
 class FieldDistParametizer(Parametizer):
     aware = BoolParam(False)
+    tree = StrParam(MODELTREE_DEFAULT_ALIAS, choices=trees)
     processor = StrParam('default', choices=pipeline.query_processors)
 
 

--- a/serrano/resources/field/stats.py
+++ b/serrano/resources/field/stats.py
@@ -1,6 +1,7 @@
 import logging
 from restlib2.http import codes
 from restlib2.params import Parametizer, BoolParam, StrParam
+from modeltree.tree import MODELTREE_DEFAULT_ALIAS, trees
 from avocado.events import usage
 from avocado.query import pipeline
 from serrano.conf import settings
@@ -12,6 +13,7 @@ log = logging.getLogger(__name__)
 
 class FieldStatsParametizer(Parametizer):
     aware = BoolParam(False)
+    tree = StrParam(MODELTREE_DEFAULT_ALIAS, choices=trees)
     processor = StrParam('default', choices=pipeline.query_processors)
 
 

--- a/serrano/resources/field/values.py
+++ b/serrano/resources/field/values.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 from django.utils.encoding import smart_unicode
 from restlib2.http import codes
 from restlib2.params import StrParam, IntParam, BoolParam
+from modeltree.tree import MODELTREE_DEFAULT_ALIAS, trees
 from avocado.events import usage
 from avocado.query import pipeline
 from .base import FieldBase, is_field_orphaned
@@ -17,6 +18,7 @@ log = logging.getLogger(__name__)
 class FieldValuesParametizer(PaginatorParametizer):
     aware = BoolParam(False)
     limit = IntParam(10)
+    tree = StrParam(MODELTREE_DEFAULT_ALIAS, choices=trees)
     processor = StrParam('default', choices=pipeline.query_processors)
     query = StrParam()
     random = IntParam()

--- a/tests/models.py
+++ b/tests/models.py
@@ -57,3 +57,7 @@ class Project(models.Model):
 class Team(ObjectSet):
     employees = models.ManyToManyField(Employee)
     context_json = jsonfield.JSONField(null=True, blank=True)
+
+
+class Unrelated(models.Model):
+    name = models.CharField(max_length=100)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,7 @@
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
     }
 }
 
@@ -64,7 +65,10 @@ SECRET_KEY = 'abc123'
 MODELTREES = {
     'default': {
         'model': 'tests.Employee',
-    }
+    },
+    'unrelated': {
+        'model': 'tests.Unrelated',
+    },
 }
 
 AVOCADO = {


### PR DESCRIPTION
This change now properly filters out fields and concepts unrelated to
the requested tree. Clients can use this parameter for these resources
to drive the context of the application.

Fix #214

Signed-off-by: Byron Ruth <b@devel.io>