### PR TITLE
Execute application stat counts in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ python:
 sudo: false
 
 env:
-    - DJANGO=1.5.12
-    - DJANGO=1.6.10
+    - DJANGO=1.5.12 TEST_DATABASE_NAME=serrano TEST_DATABASE_USER=postgres
+    - DJANGO=1.6.10 TEST_DATABASE_NAME=serrano TEST_DATABASE_USER=postgres
+
+addons:
+    postgresql: "9.3"
 
 services:
     - memcached
@@ -21,6 +24,9 @@ before_install:
 install:
     - pip install -q coverage Django==$DJANGO
     - pip install -q -r requirements.txt
+
+before_script:
+    - psql -U postgres -c 'CREATE DATABASE serrano;'
 
 script:
     - coverage run test_suite.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ django-preserialize>=1.0.7,<1.1.0
 restlib2>=0.4.2,<0.5.0
 python-memcached>=1.48
 django-objectset>=0.2.3
+psycopg2

--- a/serrano/conf/global_settings.py
+++ b/serrano/conf/global_settings.py
@@ -74,3 +74,6 @@ EXPORT_COOKIE_DATA = 'complete'
 # generated in the base field resource. Setting this to None will disable
 # stats for all fields.
 STATS_CAPABLE = lambda x: not x.searchable
+
+# Time to wait when performing a single count on the stats endpoint.
+STATS_COUNT_TIMEOUT = 5

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,7 +1,14 @@
+import os
+import getpass
+
+TEST_DATABASE_USER = os.environ.get('TEST_DATABASE_USER', getpass.getuser())
+TEST_DATABASE_NAME = os.environ.get('TEST_DATABASE_NAME', 'serrano')
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': TEST_DATABASE_NAME,
+        'USER': TEST_DATABASE_USER,
     }
 }
 


### PR DESCRIPTION
A thread pool is started that gets or executes the counts in parallel.

This requires the test database to not be SQLite, since multiple
connections are not supported while the test suite is running. See
https://github.com/django/django/blob/stable/1.6.x/django/db/backends/sqlite3/base.py#L96

Fix #252

Signed-off-by: Byron Ruth <b@devel.io>