### PR TITLE
Implement DELETE method for data preview and export resources

### DIFF
--- a/tests/cases/resources/tests/preview.py
+++ b/tests/cases/resources/tests/preview.py
@@ -2,10 +2,10 @@ import json
 from django.contrib.auth.models import User
 from django.test import TestCase
 from restlib2.http import codes
-from .base import BaseTestCase
+from .base import TransactionBaseTestCase
 
 
-class PreviewResourceProcessorTestCase(BaseTestCase):
+class PreviewResourceProcessorTestCase(TransactionBaseTestCase):
     def test_no_processor(self):
         response = self.client.get('/api/data/preview/',
                                    HTTP_ACCEPT='application/json')


### PR DESCRIPTION
This enables a separate request to cancel a long-running query in a
prior request.

Fix #265

Signed-off-by: Byron Ruth <b@devel.io>