### PR TITLE
Add a common utility method for calculating result rows

### DIFF
--- a/serrano/resources/exporter.py
+++ b/serrano/resources/exporter.py
@@ -70,16 +70,16 @@ class ExporterResource(BaseResource):
 
         try:
             rows, row_options = get_result_rows(
-                context,
-                view,
-                params.get('limit'),
-                params.get('tree'),
-                params.get('processor'),
-                kwargs.get('page'),
-                kwargs.get('stop_page'),
-                query_name,
-                params.get('reader'),
-                export_type
+                context=context,
+                view=view,
+                limit=params.get('limit'),
+                tree=params.get('tree'),
+                processor_name=params.get('processor'),
+                page=kwargs.get('page'),
+                stop_page=kwargs.get('stop_page'),
+                query_name=query_name,
+                reader=params.get('reader'),
+                export_type=export_type
             )
         except ValueError:
             raise Http404

--- a/serrano/resources/exporter.py
+++ b/serrano/resources/exporter.py
@@ -10,6 +10,8 @@ from avocado.events import usage
 from ..conf import settings
 from . import API_VERSION
 from .base import BaseResource
+from ..utils import get_result_rows
+
 
 # Single list of all registered exporters
 EXPORT_TYPES = zip(*exporters.choices)[0]
@@ -61,99 +63,41 @@ class ExporterResource(BaseResource):
     parametizer = ExporterParametizer
 
     def _export(self, request, export_type, view, context, **kwargs):
-        # Handle an explicit export type to a file
-        resp = HttpResponse()
-
         params = self.get_params(request)
 
-        limit = params.get('limit')
-        tree = params.get('tree')
-
-        page = kwargs.get('page')
-        stop_page = kwargs.get('stop_page')
-
-        offset = None
-
-        # Restrict export to a particular page or page range
-        if page:
-            page = int(page)
-
-            # Pages are 1-based
-            if page < 1:
-                raise Http404
-
-            file_tag = 'p{0}'.format(page)
-
-            # Change to 0-base for calculating offset
-            offset = limit * (page - 1)
-
-            if stop_page:
-                stop_page = int(stop_page)
-
-                # Cannot have a lower index than page
-                if stop_page < page:
-                    raise Http404
-
-                # 4...5 means 4 and 5, not everything up to 5 like with
-                # list slices, so 4...4 is equivalent to just 4
-                if stop_page > page:
-                    file_tag = 'p{0}-{1}'.format(page, stop_page)
-                    limit = limit * stop_page
-
-        else:
-            # When no page or range is specified, the limit does not apply.
-            limit = None
-            file_tag = 'all'
-
-        QueryProcessor = pipeline.query_processors[params['processor']]
-
-        processor = QueryProcessor(context=context,
-                                   view=view,
-                                   tree=tree,
-                                   include_pk=False)
-
-        queryset = processor.get_queryset(request=request)
-
-        # Isolate this query and subsequent queries to a named connection.
-        # Cancel the outstanding query if one is present.
         # Use a separate name for each for export type.
         query_name = '{0}:{1}'.format(request.session.session_key, export_type)
-        utils.cancel_query(query_name)
 
-        queryset = utils.isolate_queryset(query_name, queryset)
+        try:
+            rows, row_options = get_result_rows(
+                context,
+                view,
+                params.get('limit'),
+                params.get('tree'),
+                params.get('processor'),
+                kwargs.get('page'),
+                kwargs.get('stop_page'),
+                query_name,
+                params.get('reader'),
+                export_type
+            )
+        except ValueError:
+            raise Http404
 
-        # Get the exporter for this type.
-        exporter = processor.get_exporter(exporters[export_type])
+        exporter = row_options['exporter']
+        page = row_options['page']
+        stop_page = row_options['stop_page']
 
-        # This is an optimization when concepts are selected for ordering
-        # only. There is not guarantee to how many rows are required to get
-        # the desired `limit` of rows, so the query is unbounded. If all
-        # ordering facets are visible, the limit and offset can be pushed
-        # down to the query.
-        order_only = lambda f: not f.get('visible', True)
+        # Build a file name for the export file based on the page range.
+        if page:
+            file_tag = 'p{0}'.format(page)
 
-        view_node = view.parse()
-
-        if filter(order_only, view_node.facets):
-            iterable = processor.get_iterable(queryset=queryset,
-                                              request=request)
-
-            rows = exporter.manual_read(iterable,
-                                        request=request,
-                                        offset=offset,
-                                        limit=limit)
+            if stop_page and stop_page > page:
+                file_tag = 'p{0}-{1}'.format(page, stop_page)
         else:
-            iterable = processor.get_iterable(queryset=queryset,
-                                              request=request,
-                                              limit=limit,
-                                              offset=offset)
+            file_tag = 'all'
 
-            # Get the requested reader
-            reader = params['reader']
-            method = exporter.reader(reader)
-
-            rows = method(iterable, request=request)
-
+        resp = HttpResponse()
         exporter.write(rows,
                        buff=resp,
                        request=request)

--- a/serrano/resources/preview.py
+++ b/serrano/resources/preview.py
@@ -7,10 +7,11 @@ from django.core.urlresolvers import reverse
 from django.http import Http404
 from modeltree.tree import MODELTREE_DEFAULT_ALIAS, trees
 from restlib2.params import Parametizer, IntParam, StrParam
-from avocado.query import pipeline, utils
 from avocado.export import HTMLExporter
+from avocado.query import pipeline, utils
 from .base import BaseResource
 from ..links import patch_response
+from ..utils import get_result_rows
 
 
 def get_page_links(request, path, page, limit, extra=None):
@@ -86,93 +87,25 @@ class PreviewResource(BaseResource):
     def get(self, request, **kwargs):
         params = self.get_params(request)
 
-        limit = params.get('limit')
-        tree = params.get('tree')
-
-        page = kwargs.get('page')
-        stop_page = kwargs.get('stop_page')
-
-        offset = None
-
-        # Restrict the preview results to a particular page or page range.
-        if page:
-            page = int(page)
-
-            # Pages are 1-based
-            if page < 1:
-                raise Http404
-
-            # Change to 0-base for calculating offset
-            offset = limit * (page - 1)
-
-            if stop_page:
-                stop_page = int(stop_page)
-
-                # Cannot have a lower index than page
-                if stop_page < page:
-                    raise Http404
-
-                # 4...5 means 4 and 5, not everything up to 5 like with
-                # list slices, so 4...4 is equivalent to just 4
-                if stop_page > page:
-                    limit = limit * stop_page
-        else:
-            limit = None
-
         # Get the request's view and context
         view = self.get_view(request)
         context = self.get_context(request)
 
-        # Initialize a query processor
-        QueryProcessor = pipeline.query_processors[params['processor']]
-        processor = QueryProcessor(context=context, view=view, tree=tree)
-
-        # Build a queryset for pagination and other downstream use
-        queryset = processor.get_queryset(request=request)
-
-        # Isolate this query and subsequent queries to a named connection.
-        # Cancel the outstanding query if one is present.
-        query_name = request.session.session_key
-        utils.cancel_query(query_name)
-
-        queryset = utils.isolate_queryset(query_name, queryset)
-
-        # 0 limit means all for pagination, however the read method requires
-        # an explicit limit of None
-        limit = limit or None
-
-        # Prepare an HTMLExporter
-        exporter = processor.get_exporter(HTMLExporter)
-
-        objects = []
-
-        # This is an optimization when concepts are selected for ordering
-        # only. There is not guarantee to how many rows are required to get
-        # the desired `limit` of rows, so the query is unbounded. If all
-        # ordering facets are visible, the limit and offset can be pushed
-        # down to the query.
-        view_node = view.parse()
-        order_only = lambda f: not f.get('visible', True)
-
-        if filter(order_only, view_node.facets):
-            iterable = processor.get_iterable(queryset=queryset,
-                                              request=request)
-
-            rows = exporter.manual_read(iterable,
-                                        request=request,
-                                        offset=offset,
-                                        limit=limit)
-        else:
-            iterable = processor.get_iterable(queryset=queryset,
-                                              request=request,
-                                              limit=limit,
-                                              offset=offset)
-
-            # Get the requested reader
-            reader = params['reader']
-            method = exporter.reader(reader)
-
-            rows = method(iterable, request=request)
+        try:
+            rows, row_options = get_result_rows(
+                context,
+                view,
+                params.get('limit'),
+                params.get('tree'),
+                params.get('processor'),
+                kwargs.get('page'),
+                kwargs.get('stop_page'),
+                request.session.session_key,
+                params.get('reader'),
+                HTMLExporter.short_name
+            )
+        except ValueError:
+            raise Http404
 
         objects = []
 
@@ -184,12 +117,13 @@ class PreviewResource(BaseResource):
             })
 
         header = []
+        view_node = view.parse()
         concepts = view_node.get_concepts_for_select()
         ordering = OrderedDict(view_node.ordering)
 
         # Skip the primary key field in the header since it is not exposed
         # in the row output below.
-        for i, f in enumerate(exporter.header[1:]):
+        for i, f in enumerate(row_options['exporter'].header[1:]):
             concept = concepts[i]
 
             obj = {
@@ -203,7 +137,7 @@ class PreviewResource(BaseResource):
             header.append(obj)
 
         # Various model options
-        opts = queryset.model._meta
+        opts = row_options['queryset'].model._meta
 
         model_name = opts.verbose_name.format()
         model_name_plural = opts.verbose_name_plural.format()
@@ -213,13 +147,14 @@ class PreviewResource(BaseResource):
             'items': objects,
             'item_name': model_name,
             'item_name_plural': model_name_plural,
-            'limit': limit,
+            'limit': row_options['limit'],
         }
 
         response = self.render(request, content=data)
 
         path = reverse('serrano:data:preview')
-        links = get_page_links(request, path, page, limit, extra=params)
+        links = get_page_links(request, path, row_options['page'],
+                               row_options['limit'], extra=params)
 
         return patch_response(request, response, links, {})
 

--- a/serrano/resources/preview.py
+++ b/serrano/resources/preview.py
@@ -93,16 +93,16 @@ class PreviewResource(BaseResource):
 
         try:
             rows, row_options = get_result_rows(
-                context,
-                view,
-                params.get('limit'),
-                params.get('tree'),
-                params.get('processor'),
-                kwargs.get('page'),
-                kwargs.get('stop_page'),
-                request.session.session_key,
-                params.get('reader'),
-                HTMLExporter.short_name
+                context=context,
+                view=view,
+                limit=params.get('limit'),
+                tree=params.get('tree'),
+                processor_name=params.get('processor'),
+                page=kwargs.get('page'),
+                stop_page=kwargs.get('stop_page'),
+                query_name=request.session.session_key,
+                reader=params.get('reader'),
+                export_type=HTMLExporter.short_name
             )
         except ValueError:
             raise Http404

--- a/serrano/resources/query/results.py
+++ b/serrano/resources/query/results.py
@@ -2,8 +2,9 @@ from django.http import Http404, HttpResponse
 from restlib2.params import IntParam
 
 from avocado.export import JSONExporter
-from avocado.query import pipeline, utils as query_utils
+from avocado.query import utils as query_utils
 from serrano.resources.query.base import QueryBase, QueryParametizer
+from ...utils import get_result_rows
 
 
 class QueryResultsParametizer(QueryParametizer):
@@ -43,84 +44,33 @@ class QueryResultsResource(QueryBase):
         return self.get_object(request, **kwargs) is None
 
     def get(self, request, **kwargs):
-        context = request.instance.context
-        view = request.instance.view
-
         params = self.get_params(request)
 
-        limit = params.get('limit')
-        tree = params.get('tree')
-
-        page = kwargs.get('page')
-        stop_page = kwargs.get('stop_page')
-
-        offset = None
-
-        if page:
-            page = int(page)
-
-            # Pages are 1-based.
-            if page < 1:
-                raise Http404
-
-            # Change to 0-base for calculating offset.
-            offset = limit * (page - 1)
-
-            if stop_page:
-                stop_page = int(stop_page)
-
-                # Cannot have a lower index stop page than start page.
-                if stop_page < page:
-                    raise Http404
-
-                # 4...5 means 4 and 5, not everything up to 5 like with
-                # list slices, so 4...4 is equivalent to just 4
-                if stop_page > page:
-                    limit = limit * stop_page
-        else:
-            # When no page or range is specified, the limit does not apply.
-            limit = None
-
-        QueryProcessor = pipeline.query_processors[params['processor']]
-        processor = QueryProcessor(context=context, view=view, tree=tree)
-        queryset = processor.get_queryset(request=request)
+        context = request.instance.context
+        view = request.instance.view
 
         # Isolate this query to a named connection. This will cancel an
         # outstanding queries of the same name if one is present.
         query_name = self.QUERY_NAME_TEMPLATE.format(pk=request.instance.pk)
-        query_utils.cancel_query(query_name)
-        queryset = query_utils.isolate_queryset(query_name, queryset)
 
-        exporter = processor.get_exporter(JSONExporter)
+        try:
+            rows, row_options = get_result_rows(
+                context,
+                view,
+                params.get('limit'),
+                params.get('tree'),
+                params.get('processor'),
+                kwargs.get('page'),
+                kwargs.get('stop_page'),
+                query_name,
+                params.get('reader'),
+                JSONExporter.short_name.lower()
+            )
+        except ValueError:
+            raise Http404
 
-        # This is an optimization when concepts are selected for ordering
-        # only. There is no guarantee to how many rows are required to get
-        # the desired `limit` of rows, so the query is unbounded. If all
-        # ordering facets are visible, the limit and offset can be pushed
-        # down to the query.
-        order_only = lambda f: not f.get('visible', True)
-        view_node = view.parse()
         resp = HttpResponse()
-
-        if filter(order_only, view_node.facets):
-            iterable = processor.get_iterable(queryset=queryset,
-                                              request=request)
-
-            # Write the data to the response
-            exporter.write(iterable,
-                           resp,
-                           request=request,
-                           offset=offset,
-                           limit=limit)
-        else:
-            iterable = processor.get_iterable(queryset=queryset,
-                                              request=request,
-                                              limit=limit,
-                                              offset=offset)
-
-            exporter.write(iterable,
-                           resp,
-                           request=request)
+        row_options['exporter'].write(rows, buff=resp, request=request)
 
         return resp
 

--- a/serrano/resources/query/results.py
+++ b/serrano/resources/query/results.py
@@ -49,8 +49,6 @@ class QueryResultsResource(QueryBase):
         context = request.instance.context
         view = request.instance.view
 
-        # Isolate this query to a named connection. This will cancel an
-        # outstanding queries of the same name if one is present.
         query_name = self.QUERY_NAME_TEMPLATE.format(pk=request.instance.pk)
 
         try:

--- a/serrano/resources/query/results.py
+++ b/serrano/resources/query/results.py
@@ -55,16 +55,16 @@ class QueryResultsResource(QueryBase):
 
         try:
             rows, row_options = get_result_rows(
-                context,
-                view,
-                params.get('limit'),
-                params.get('tree'),
-                params.get('processor'),
-                kwargs.get('page'),
-                kwargs.get('stop_page'),
-                query_name,
-                params.get('reader'),
-                JSONExporter.short_name.lower()
+                context=context,
+                view=view,
+                limit=params.get('limit'),
+                tree=params.get('tree'),
+                processor_name=params.get('processor'),
+                page=kwargs.get('page'),
+                stop_page=kwargs.get('stop_page'),
+                query_name=query_name,
+                reader=params.get('reader'),
+                export_type=JSONExporter.short_name.lower()
             )
         except ValueError:
             raise Http404

--- a/serrano/utils.py
+++ b/serrano/utils.py
@@ -38,7 +38,12 @@ def send_mail(emails, subject, message, async=True, fail_silently=True):
 def get_result_rows(context, view, limit, tree, processor_name, page,
                     stop_page, query_name, reader, export_type):
     """
-    TODO: Doctstring
+    Returns the result rows and options given the supplied arguments.
+
+    The options include the exporter, queryset, offset, limit, page, and
+    stop_page that were used when calculating the result rows. These can give
+    some more context to callers of this method as far as the returned row
+    set is concerned.
     """
     offset = None
 

--- a/serrano/utils.py
+++ b/serrano/utils.py
@@ -1,6 +1,8 @@
 from threading import Thread
 from django.conf import settings
 from django.core import mail
+from avocado.export import HTMLExporter, registry as exporters
+from avocado.query import pipeline, utils as query_utils
 
 
 def _send_mail(subject, message, sender, recipient_list, fail_silently):
@@ -31,3 +33,91 @@ def send_mail(emails, subject, message, async=True, fail_silently=True):
     else:
         _send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, emails,
                    fail_silently)
+
+
+def get_result_rows(context, view, limit, tree, processor_name, page,
+                    stop_page, query_name, reader, export_type):
+    """
+    TODO: Doctstring
+    """
+    offset = None
+
+    if page:
+        page = int(page)
+
+        # Pages are 1-based.
+        if page < 1:
+            raise ValueError('Page must be greater than or equal to 1.')
+
+        # Change to 0-base for calculating offset.
+        offset = limit * (page - 1)
+
+        if stop_page:
+            stop_page = int(stop_page)
+
+            # Cannot have a lower index stop page than start page.
+            if stop_page < page:
+                raise ValueError(
+                    'Stop page must be greater than or equal to start page.')
+
+            # 4...5 means 4 and 5, not everything up to 5 like with
+            # list slices, so 4...4 is equivalent to just 4
+            if stop_page > page:
+                limit = limit * stop_page
+    else:
+        # When no page or range is specified, the limit does not apply.
+        limit = None
+
+    QueryProcessor = pipeline.query_processors[processor_name]
+    processor = QueryProcessor(context=context, view=view, tree=tree)
+    queryset = processor.get_queryset()
+
+    # Isolate this query to a named connection. This will cancel an
+    # outstanding queries of the same name if one is present.
+    query_utils.cancel_query(query_name)
+    queryset = query_utils.isolate_queryset(query_name, queryset)
+
+    # 0 limit means all for pagination, however the read method requires
+    # an explicit limit of None
+    limit = limit or None
+
+    # We use HTMLExporter in Serrano but Avocado has it disabled. Until it
+    # is enabled in Avocado, we can reference the HTMLExporter directly here.
+    if export_type.lower() == 'html':
+        exporter = processor.get_exporter(HTMLExporter)
+    else:
+        exporter = processor.get_exporter(exporters[export_type])
+
+    # This is an optimization when concepts are selected for ordering
+    # only. There is no guarantee to how many rows are required to get
+    # the desired `limit` of rows, so the query is unbounded. If all
+    # ordering facets are visible, the limit and offset can be pushed
+    # down to the query.
+    order_only = lambda f: not f.get('visible', True)
+    view_node = view.parse()
+
+    if filter(order_only, view_node.facets):
+        iterable = processor.get_iterable(queryset=queryset)
+        rows = exporter.manual_read(iterable,
+                                    offset=offset,
+                                    limit=limit)
+    else:
+        iterable = processor.get_iterable(queryset=queryset,
+                                          limit=limit,
+                                          offset=offset)
+        iterable = processor.get_iterable(queryset=queryset,
+                                          limit=limit,
+                                          offset=offset)
+        method = exporter.reader(reader)
+        rows = method(iterable)
+
+    options = {
+        'exporter': exporter,
+        'queryset': queryset,
+        'offset': offset,
+        'limit': limit,
+        'page': page,
+        'stop_page': stop_page,
+    }
+
+    return rows, options


### PR DESCRIPTION
This adds a common method for calculating result rows and is meant to remove redundant code in the following endpoints:

 * preview
 * exporter
 * query results

This will also be needed for the upcoming deferred job processing work.