### PR TITLE
Add support for Django 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ sudo: false
 env:
     - DJANGO=1.5.12 TEST_DATABASE_NAME=serrano TEST_DATABASE_USER=postgres
     - DJANGO=1.6.10 TEST_DATABASE_NAME=serrano TEST_DATABASE_USER=postgres
+    - DJANGO=1.7.10 TEST_DATABASE_NAME=serrano TEST_DATABASE_USER=postgres
 
 addons:
     postgresql: "9.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+git://github.com/cbmi/avocado.git
-django-preserialize>=1.0.7,<1.1.0
+django-preserialize>=1.1.0,<1.2.0
 restlib2>=0.4.2,<0.5.0
 python-memcached>=1.48
 django-objectset>=0.2.3

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 install_requires = [
     'avocado>=2.4.0,<2.5',
     'restlib2>=0.4.2,<0.5.0',
-    'django-preserialize>=1.0.7,<1.1',
+    'django-preserialize>=1.1.0,<1.2.0',
 ]
 
 if sys.version_info < (2, 7):

--- a/test_suite.py
+++ b/test_suite.py
@@ -3,6 +3,10 @@ import sys
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
 
+import django
+if hasattr(django, 'setup'):
+    django.setup()
+
 from django.core import management
 
 apps = sys.argv[1:]


### PR DESCRIPTION
@bruth 

This PR adds support for Django 1.7. It is a very simple change. The test runner needed a minor tweak to call `setup()` and we needed to bump the required version of `django-preserialize` to get the Django 1.7 compatible version. Finally, I added a Django 1.7 build version to Travis but locally testing passed using Django 1.7.10.