### PR TITLE
Include the page in the preview response

### DIFF
--- a/serrano/resources/processors.py
+++ b/serrano/resources/processors.py
@@ -175,6 +175,7 @@ class PreviewResultProcessor(BaseResultProcessor):
             'item_name': model_name,
             'item_name_plural': model_name_plural,
             'limit': result_data['limit'],
+            'page': result_data['page'],
         }
 
         response = HttpResponse(

--- a/tests/cases/resources/tests/async/preview.py
+++ b/tests/cases/resources/tests/async/preview.py
@@ -116,6 +116,7 @@ class AsyncPreviewResourceTestCase(TestCase, JobTestCaseMixin):
             'keys': [],
             'limit': None,
             'item_name_plural': 'employees',
+            'page': None,
         })
 
     def test_get_page(self):
@@ -128,6 +129,7 @@ class AsyncPreviewResourceTestCase(TestCase, JobTestCaseMixin):
             'keys': [],
             'item_name_plural': 'employees',
             'limit': 20,
+            'page': 7,
         })
 
     def test_get_page_range_equal(self):
@@ -141,6 +143,7 @@ class AsyncPreviewResourceTestCase(TestCase, JobTestCaseMixin):
             'keys': [],
             'item_name_plural': 'employees',
             'limit': 20,
+            'page': 3,
         }
         links = (
             '<http://testserver/api/async/preview/?limit=20&page=2>; rel="prev", '   # noqa
@@ -161,6 +164,7 @@ class AsyncPreviewResourceTestCase(TestCase, JobTestCaseMixin):
             'keys': [],
             'item_name_plural': 'employees',
             'limit': 100,
+            'page': 1,
         })
 
     def test_get_limit(self):
@@ -173,6 +177,7 @@ class AsyncPreviewResourceTestCase(TestCase, JobTestCaseMixin):
             'keys': [],
             'item_name_plural': 'employees',
             'limit': 1000,
+            'page': 1,
         })
 
     def test_get_with_user(self):
@@ -189,6 +194,7 @@ class AsyncPreviewResourceTestCase(TestCase, JobTestCaseMixin):
             'keys': [],
             'limit': None,
             'item_name_plural': 'employees',
+            'page': None,
         }
         links = (
             '<http://testserver/api/async/preview/>; rel="self"'

--- a/tests/cases/resources/tests/preview.py
+++ b/tests/cases/resources/tests/preview.py
@@ -48,6 +48,7 @@ class PreviewResourceTestCase(TestCase):
             'keys': [],
             'limit': None,
             'item_name_plural': 'employees',
+            'page': None,
         })
 
     def test_get_invalid(self):
@@ -66,6 +67,7 @@ class PreviewResourceTestCase(TestCase):
             'keys': [],
             'item_name_plural': 'employees',
             'limit': 20,
+            'page': 7,
         })
 
     def test_get_page_range_equal(self):
@@ -79,6 +81,7 @@ class PreviewResourceTestCase(TestCase):
             'keys': [],
             'item_name_plural': 'employees',
             'limit': 20,
+            'page': 3,
         })
         self.assertEqual(response['Link'], (
             '<http://testserver/api/data/preview/?limit=20&page=2>; rel="prev", '   # noqa
@@ -99,6 +102,7 @@ class PreviewResourceTestCase(TestCase):
             'keys': [],
             'item_name_plural': 'employees',
             'limit': 100,
+            'page': 1,
         })
 
     def test_get_limit(self):
@@ -112,6 +116,7 @@ class PreviewResourceTestCase(TestCase):
             'keys': [],
             'item_name_plural': 'employees',
             'limit': 1000,
+            'page': 1,
         })
 
     def test_get_with_user(self):
@@ -128,6 +133,7 @@ class PreviewResourceTestCase(TestCase):
             'keys': [],
             'limit': None,
             'item_name_plural': 'employees',
+            'page': None,
         })
         self.assertEqual(response['Link'], (
             '<http://testserver/api/data/preview/>; rel="self"'


### PR DESCRIPTION
@bruth 

Like the limit, the client can also specify a page. We have historically relied on getting the page back in Cilantro so I think we should continue doing it here. Also, it will behave more like limit which is a parameter that is returned in the response.

Signed-off-by: Don Naegely <naegelyd@gmail.com>