### PR TITLE
Add endpoints for SQL representation of queries

### DIFF
--- a/serrano/resources/query/__init__.py
+++ b/serrano/resources/query/__init__.py
@@ -6,13 +6,14 @@ from serrano.resources import templates
 from serrano.resources.history import ObjectRevisionResource, \
     ObjectRevisionsResource, RevisionsResource
 from serrano.resources.query.base import PublicQueriesResource, \
-    QueryResource, QueriesResource
+    QueryResource, QueriesResource, QuerySqlResource
 from serrano.resources.query.forks import QueryForksResource
 from serrano.resources.query.results import QueryResultsResource
 from serrano.resources.query.stats import QueryStatsResource
 
 single_resource = never_cache(QueryResource())
 active_resource = never_cache(QueriesResource())
+sql_resource = never_cache(QuerySqlResource())
 public_resource = never_cache(PublicQueriesResource())
 forks_resource = never_cache(QueryForksResource())
 stats_resource = never_cache(QueryStatsResource())
@@ -105,6 +106,19 @@ urlpatterns = patterns(
         stats_resource,
         {'session': True},
         name='stats'
+    ),
+
+    # SQL
+    url(
+        r'^(?P<pk>\d+)/sql/$',
+        sql_resource,
+        name='sql'
+    ),
+    url(
+        r'^session/sql/$',
+        sql_resource,
+        {'session': True},
+        name='sql'
     ),
 
     # Forks


### PR DESCRIPTION
This change introduces three new endpoints that returns an SQL
representation for with respect to the context, view, and query.

For example, going to /api/contexts/session/sql/ will return the SQL
for just the context whereas /api/views/session/sql/ will return the
SQL for just the view component. /api/views/queries/sql/ will return
the composite of the two which is the basis for the query results.

Signed-off-by: Byron Ruth <b@devel.io>