### PR TITLE
Limit access to SQL resources

### DIFF
--- a/serrano/resources/context.py
+++ b/serrano/resources/context.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 from datetime import datetime
+from django.conf import settings
 from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse
 from django.views.decorators.cache import never_cache
@@ -246,6 +247,17 @@ def prune_context(cxt):
 
 
 class ContextSqlResource(ContextBase):
+    def is_unauthorized(self, request, *args, **kwargs):
+        if super(ContextSqlResource, self)\
+                .is_unauthorized(request, *args, **kwargs):
+            return True
+
+        return not any((
+            request.user.is_superuser,
+            request.user.is_staff,
+            settings.DEBUG,
+        ))
+
     def is_not_found(self, request, response, **kwargs):
         return self.get_object(request, **kwargs) is None
 

--- a/serrano/resources/query/base.py
+++ b/serrano/resources/query/base.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import functools
 
 from django.db.models import Q
+from django.conf import settings
 from modeltree.tree import trees, MODELTREE_DEFAULT_ALIAS
 from preserialize.serialize import serialize
 from restlib2.http import codes
@@ -258,6 +259,17 @@ def prune_context(cxt):
 
 
 class QuerySqlResource(QueryBase):
+    def is_unauthorized(self, request, *args, **kwargs):
+        if super(QuerySqlResource, self)\
+                .is_unauthorized(request, *args, **kwargs):
+            return True
+
+        return not any((
+            request.user.is_superuser,
+            request.user.is_staff,
+            settings.DEBUG,
+        ))
+
     def is_not_found(self, request, response, **kwargs):
         return self.get_object(request, **kwargs) is None
 

--- a/serrano/resources/view.py
+++ b/serrano/resources/view.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from django.conf import settings
 from django.conf.urls import patterns, url
 from django.views.decorators.cache import never_cache
 from restlib2.http import codes
@@ -180,6 +181,17 @@ class ViewResource(ViewBase):
 
 
 class ViewSqlResource(ViewBase):
+    def is_unauthorized(self, request, *args, **kwargs):
+        if super(ViewSqlResource, self)\
+                .is_unauthorized(request, *args, **kwargs):
+            return True
+
+        return not any((
+            request.user.is_superuser,
+            request.user.is_staff,
+            settings.DEBUG,
+        ))
+
     def is_not_found(self, request, response, **kwargs):
         return self.get_object(request, **kwargs) is None
 


### PR DESCRIPTION
The resources implemented in 9627aa6 return SQL which may expose some
sensitive internal details such as implicit filtering given a user.

Signed-off-by: Byron Ruth <b@devel.io>