### PR TITLE
Allow unauthorized preflight requests

### DIFF
--- a/serrano/cors.py
+++ b/serrano/cors.py
@@ -1,6 +1,11 @@
 from serrano.conf import settings
 
 
+def is_preflight(request):
+    return (request.method == 'OPTIONS' and
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' in request.META)
+
+
 def patch_response(request, response, methods):
     if settings.CORS_ENABLED:
         allowed_origins = settings.CORS_ORIGINS

--- a/serrano/middleware.py
+++ b/serrano/middleware.py
@@ -1,4 +1,5 @@
 from django.core.urlresolvers import reverse
+from .cors import is_preflight
 from .tokens import get_request_token
 
 
@@ -9,7 +10,7 @@ class SessionMiddleware(object):
 
         # Token-based authentication is attempting to be used, bypass CSRF
         # check. Allow POST requests to the root endpoint for authentication.
-        if get_request_token(request) or \
+        if get_request_token(request) or is_preflight(request) or \
                 (request.method == 'POST' and
                  request.path == reverse('serrano:root')):
             request.csrf_processing_done = True

--- a/serrano/resources/base.py
+++ b/serrano/resources/base.py
@@ -192,6 +192,9 @@ class BaseResource(Resource):
     parametizer = Parametizer
 
     def is_unauthorized(self, request, *args, **kwargs):
+        if cors.is_preflight(request):
+            return
+
         user = getattr(request, 'user', None)
 
         # Attempt to authenticate if a token is present


### PR DESCRIPTION
A preflight request is done by browsers to determine if a server
accepts cross-origin requests and what the capabilities are in general.
If auth is required to access the Serrano resources, then the preflight
cannot require auth otherwise the subsequent POST would not happen to
actually do the authorization.

Signed-off-by: Byron Ruth <b@devel.io>