### PR TITLE
Pass request to async_get_result_rows for use by QueryProcessor

### DIFF
--- a/serrano/resources/async/exporter.py
+++ b/serrano/resources/async/exporter.py
@@ -41,7 +41,7 @@ class AsyncExporterResource(ExporterResource):
         }
 
         job_id = async_get_result_rows(
-            context, view, query_options, job_data)
+            context, view, query_options, job_data, request=request)
 
         return HttpResponseRedirect(
             reverse('serrano:jobs:single', kwargs={'job_uuid': job_id}))

--- a/serrano/resources/async/preview.py
+++ b/serrano/resources/async/preview.py
@@ -43,7 +43,7 @@ class AsyncPreviewResource(PreviewResource):
         }
 
         job_id = async_get_result_rows(
-            context, view, query_options, job_data)
+            context, view, query_options, job_data, request=request)
 
         return HttpResponseRedirect(
             reverse('serrano:jobs:single', kwargs={'job_uuid': job_id}))

--- a/serrano/resources/async/query.py
+++ b/serrano/resources/async/query.py
@@ -42,7 +42,8 @@ class AsyncQueryResultsResource(QueryResultsResource):
             request.instance.context,
             request.instance.view,
             query_options,
-            job_data)
+            job_data,
+            request=request)
 
         return HttpResponseRedirect(
             reverse('serrano:jobs:single', kwargs={'job_uuid': job_id}))

--- a/serrano/resources/exporter.py
+++ b/serrano/resources/exporter.py
@@ -82,13 +82,13 @@ class ExporterResource(BaseResource):
         query_options = {
             'export_type': export_type,
             'query_name': self._get_query_name(request, export_type),
-            'request': request,
         }
         query_options.update(**kwargs)
         query_options.update(params)
 
         try:
-            row_data = utils.get_result_rows(context, view, query_options)
+            row_data = utils.get_result_rows(context, view, query_options,
+                                             request=request)
         except ValueError:
             raise Http404
 

--- a/serrano/resources/preview.py
+++ b/serrano/resources/preview.py
@@ -41,13 +41,13 @@ class PreviewResource(BaseResource):
         query_options = {
             'export_type': HTMLExporter.short_name,
             'query_name': self._get_query_name(request),
-            'request': request,
         }
         query_options.update(**kwargs)
         query_options.update(params)
 
         try:
-            row_data = utils.get_result_rows(context, view, query_options)
+            row_data = utils.get_result_rows(context, view, query_options,
+                                             request=request)
         except ValueError:
             raise Http404
 

--- a/serrano/resources/query/results.py
+++ b/serrano/resources/query/results.py
@@ -54,7 +54,6 @@ class QueryResultsResource(QueryBase):
         query_options = {
             'export_type': JSONExporter.short_name.lower(),
             'query_name': self._get_query_name(request),
-            'request': request,
         }
         query_options.update(**kwargs)
         query_options.update(params)
@@ -63,7 +62,8 @@ class QueryResultsResource(QueryBase):
             row_data = query_utils.get_result_rows(
                 request.instance.context,
                 request.instance.view,
-                query_options)
+                query_options,
+                request=request)
         except ValueError:
             raise Http404
 


### PR DESCRIPTION
One way to start passing `request` into custom query processors again (after async changes removed that feature).  Must be paired with changes to Avocado.